### PR TITLE
Patch/fix bc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
         - echo $TRAVIS_BUILD_STAGE_NAME - $VERSION
         - docker build -t "${IMAGE}:${GIT_SHA}" --build-arg version=$VERSION . || travis_terminate -1
         - docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${VERSION}.${DATE}"
-        - docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${VERSION}.latest"
+        - docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${VERSION}"
       after_success:
         - echo "$REGISTRY_PASSWORD" | docker login --username $REGISTRY_USER --password-stdin
         - docker images

--- a/deploy/manifests/dynatrace-service/dynatrace-service.yaml
+++ b/deploy/manifests/dynatrace-service/dynatrace-service.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: dynatrace-service
-        image: keptn/dynatrace-service
+        image: keptn/dynatrace-service:0.6.0
         ports:
         - containerPort: 8080
         resources:

--- a/deploy/scripts/setupProblemNotification.sh
+++ b/deploy/scripts/setupProblemNotification.sh
@@ -13,7 +13,6 @@ CLUSTERVERSION=$(curl -s https://$DT_TENANT/api/v1/config/clusterversion?api-tok
 
 # Check tenant is at least 1.169
 if ($(echo $CLUSTERVERSION | jq '. > 1.168'))
-if (( $(echo "$CLUSTERVERSION > 1.168" | bc -l) ))
 then
   curl -X POST \
     "https://$DT_TENANT/api/config/v1/notifications?Api-Token=$DT_API_TOKEN" \

--- a/deploy/scripts/setupProblemNotification.sh
+++ b/deploy/scripts/setupProblemNotification.sh
@@ -12,6 +12,7 @@ KEPTN_TOKEN=$4
 CLUSTERVERSION=$(curl -s https://$DT_TENANT/api/v1/config/clusterversion?api-token=$DT_API_TOKEN | jq -r .version[0:5])
 
 # Check tenant is at least 1.169
+if ($(echo $CLUSTERVERSION | jq '. > 1.168'))
 if (( $(echo "$CLUSTERVERSION > 1.168" | bc -l) ))
 then
   curl -X POST \

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.5.0
+	github.com/keptn/go-utils v0.6.0
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094
 	gopkg.in/yaml.v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.5.0 h1:Wbl73vOCg2l+iZJ5jdQKUNNZE5PnSVmWmpWdShCPlOg=
 github.com/keptn/go-utils v0.5.0/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.6.0 h1:FTnr1tiGdIqWiUNccNw8KcTzrRDZSjif3v1KbJsAnQs=
+github.com/keptn/go-utils v0.6.0/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/releasenotes/releasenotes_0.6.0.md
+++ b/releasenotes/releasenotes_0.6.0.md
@@ -1,0 +1,11 @@
+# Release Notes 0.6.0
+
+## New Features
+- Use Dynatrace Service to set up Dynatrace OneAgent, Management Zones, Dashboards, Auto Tagging Rules and Problem Notifications [#443](https://github.com/keptn/keptn/issues/443)
+- Automatically create Keptn-specific alerting profile in Dynatrace [#1281](https://github.com/keptn/keptn/issues/1281)
+- Receive Dynatrace problem notifications and send convert them to a Keptn-internal `sh.keptn.event.problem.open` event () [#1185](https://github.com/keptn/keptn/issues/1185)
+
+## Fixed Issues
+
+## Known Limitations
+- When using Container-Optimized OS (COS) based GKE clusters, the deployed OneAgent has to be updated after the installation of Dynatrace

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,9 +1,7 @@
 # Release Notes develop
 
 ## New Features
-- Use Dynatrace Service to set up Dynatrace OneAgent, Management Zones, Dashboards, Auto Tagging Rules and Problem Notifications [#443](https://github.com/keptn/keptn/issues/443)
 
 ## Fixed Issues
 
 ## Known Limitations
-- When using Container-Optimized OS (COS) based GKE clusters, the deployed OneAgent has to be updated after the installation of Dynatrace


### PR DESCRIPTION
Some platforms (notable GKE) does not include `bc` and thus this script will fail.
Since `jq` is a prereq, we can rely on it being installed.
Adjusted the logic to compare `$CLUSTERVERSION` with `jq` and not `bc`