### PR TITLE
#107 Refactor sendEvent method for Dynatrace

### DIFF
--- a/pkg/lib/dynatrace.go
+++ b/pkg/lib/dynatrace.go
@@ -192,7 +192,7 @@ func (dt *DynatraceHelper) sendDynatraceAPIRequest(apiPath string, method string
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Api-Token "+dt.DynatraceCreds.ApiToken)
 	req.Header.Set("User-Agent", "keptn-contrib/dynatrace-service:"+os.Getenv("version"))
-	dt.Logger.Debug("Dynatrace Service version: " + os.Getenv("version"))
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -203,7 +203,10 @@ func (dt *DynatraceHelper) sendDynatraceAPIRequest(apiPath string, method string
 	defer resp.Body.Close()
 	responseBody, _ := ioutil.ReadAll(resp.Body)
 
+	dt.Logger.Debug("Dynatrace service returned status " + resp.Status)
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		dt.Logger.Debug(string(responseBody))
 		return string(responseBody), errors.New(resp.Status)
 	}
 

--- a/pkg/lib/dynatrace_events.go
+++ b/pkg/lib/dynatrace_events.go
@@ -1,0 +1,27 @@
+package lib
+
+import (
+	"encoding/json"
+)
+
+// Sends an event to the Dynatrace events API
+func (dt *DynatraceHelper) SendEvent(dtEvent interface{}) {
+	dt.Logger.Info("Sending event to Dynatrace API")
+
+	jsonString, err := json.Marshal(dtEvent)
+
+	if err != nil {
+		dt.Logger.Error("Error while generating Dynatrace API Request payload.")
+		return
+	}
+
+	body, err := dt.sendDynatraceAPIRequest("/api/v1/events", "POST", string(jsonString))
+
+	if err != nil {
+		dt.Logger.Error("Failed sending Dynatrace API request: " + err.Error())
+		dt.Logger.Error("Response Body:" + body)
+	}
+
+	dt.Logger.Debug("Dynatrace API has accepted the event")
+	dt.Logger.Debug("Response Body:" + body)
+}


### PR DESCRIPTION
This PR fixes issue #107.

In addition, I've refactored the `cd_handler.go` such that it also uses `dtHelper` to send api calls to Dynatrace.