### PR TITLE
#127 only handle events that come from the Dynatrace tenant

### DIFF
--- a/pkg/event_handler/problem_handler.go
+++ b/pkg/event_handler/problem_handler.go
@@ -55,8 +55,8 @@ const eventbroker = "EVENTBROKER"
 
 func (eh ProblemEventHandler) HandleEvent() error {
 
-	if eh.Event.Source() != "https://github.com/keptn/keptn/api" {
-		eh.Logger.Debug("Will not handle problem event that did not go through the API (event source = " + eh.Event.Source() + ")")
+	if eh.Event.Source() != "dynatrace" {
+		eh.Logger.Debug("Will not handle problem event that did not come from a Dynatrace Problem Notification (event source = " + eh.Event.Source() + ")")
 		return nil
 	}
 	var shkeptncontext string

--- a/pkg/lib/dynatrace.go
+++ b/pkg/lib/dynatrace.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const DefaultOperatorVersion = "v0.5.2"
+const DefaultOperatorVersion = "v0.6.0"
 const sliResourceURI = "dynatrace/sli.yaml"
 const Throughput = "throughput"
 const ErrorRate = "error_rate"
@@ -232,9 +232,9 @@ func (dt *DynatraceHelper) GetDTCredentials() (*DTCredentials, error) {
 
 	dtCreds := &DTCredentials{}
 
-	dtCreds.Tenant = string(secret.Data["DT_TENANT"])
-	dtCreds.ApiToken = string(secret.Data["DT_API_TOKEN"])
-	dtCreds.PaaSToken = string(secret.Data["DT_PAAS_TOKEN"])
+	dtCreds.Tenant = strings.Trim(string(secret.Data["DT_TENANT"]), "\n")
+	dtCreds.ApiToken = strings.Trim(string(secret.Data["DT_API_TOKEN"]), "\n")
+	dtCreds.PaaSToken = strings.Trim(string(secret.Data["DT_PAAS_TOKEN"]), "\n")
 
 	return dtCreds, nil
 }

--- a/pkg/lib/dynatrace_api_models.go
+++ b/pkg/lib/dynatrace_api_models.go
@@ -506,19 +506,6 @@ func CreateKeptnAlertingProfile() *AlertingProfile {
 			},
 		},
 		ManagementZoneID: nil,
-		EventTypeFilters: []*AlertingProfileEventTypeFilter{
-			{
-				CustomEventFilter: CustomEventFilter{
-					CustomTitleFilter: CustomTitleFilter{
-						Enabled:         true,
-						Value:           "Keptn",
-						Operator:        "CONTAINS",
-						Negate:          false,
-						CaseInsensitive: true,
-					},
-				},
-			},
-		},
 	}
 }
 

--- a/pkg/lib/one_agent.go
+++ b/pkg/lib/one_agent.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -45,26 +44,7 @@ func (dt *DynatraceHelper) isDynatraceDeployed() bool {
 }
 
 func (dt *DynatraceHelper) deployDTOperator() error {
-	// get latest operator version
-	resp, err := http.Get("https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest")
-	if err == nil {
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-
-		operatorInfo := &dtOperatorReleaseInfo{}
-
-		err = json.Unmarshal(body, operatorInfo)
-
-		if err == nil {
-			dt.OperatorTag = operatorInfo.TagName
-		}
-	}
-	if dt.OperatorTag != "" {
-		dt.Logger.Info("Deploying Dynatrace operator " + dt.OperatorTag)
-	} else {
-		dt.Logger.Info("Could not fetch latest Dynatrace operator version. Using " + DefaultOperatorVersion + " per default.")
-		dt.OperatorTag = DefaultOperatorVersion
-	}
+	dt.OperatorTag = DefaultOperatorVersion
 
 	platform := os.Getenv("PLATFORM")
 


### PR DESCRIPTION
This avoids handling events that were sent out by the dynatrace-service itself (i.e. infinite loops)

Additional fixes:
- Remove event type filter from alerting profile
- Fixed DT operator version to 0.6.0