### PR TITLE
#1818 send problem comments when actions are triggered/finished

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,8 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.2
+	github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 )
-
-replace github.com/keptn/go-utils => github.com/keptn/go-utils v0.6.1-compat

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/keptn/go-utils v0.6.1-compat h1:Uqd0fmbPRxIqXpRv4q/q/O+KjAnJa+moZ85H1
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1 h1:zpMDtWbrrp+C9R4A8fiBje720BQjsRLUb1NAWpHtIkI=
 github.com/keptn/go-utils v0.6.1/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83 h1:DbyMq5ELazflrYbajEjHlnlVc02qcGqygvayYHhHyDo=
+github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/event_handler/action.go
+++ b/pkg/event_handler/action.go
@@ -22,6 +22,7 @@ func (eh ActionHandler) HandleEvent() error {
 		return err
 	}
 	dynatraceHelper, err := lib.NewDynatraceHelper(keptnHandler)
+	dynatraceHelper.Logger = eh.Logger
 	if err != nil {
 		eh.Logger.Error("could not initialize Dynatrace helper: " + err.Error())
 		return err

--- a/pkg/event_handler/action.go
+++ b/pkg/event_handler/action.go
@@ -1,0 +1,89 @@
+package event_handler
+
+import (
+	"errors"
+
+	"github.com/keptn-contrib/dynatrace-service/pkg/lib"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	keptn "github.com/keptn/go-utils/pkg/lib"
+)
+
+type ActionHandler struct {
+	Logger *keptn.Logger
+	Event  cloudevents.Event
+}
+
+func (eh ActionHandler) HandleEvent() error {
+
+	keptnHandler, err := keptn.NewKeptn(&eh.Event, keptn.KeptnOpts{})
+	if err != nil {
+		eh.Logger.Error("could not initialize Keptn handler: " + err.Error())
+		return err
+	}
+	dynatraceHelper, err := lib.NewDynatraceHelper(keptnHandler)
+	if err != nil {
+		eh.Logger.Error("could not initialize Dynatrace helper: " + err.Error())
+		return err
+	}
+
+	keptnBase := &baseKeptnEvent{
+		project: keptnHandler.KeptnBase.Project,
+		stage:   keptnHandler.KeptnBase.Stage,
+		service: keptnHandler.KeptnBase.Service,
+	}
+
+	dynatraceConfig, _ := getDynatraceConfig(keptnBase, eh.Logger)
+
+	dtCreds := ""
+	if dynatraceConfig != nil {
+		dtCreds = dynatraceConfig.DtCreds
+	}
+
+	var comment string
+	var pid string
+
+	if eh.Event.Type() == keptn.ActionTriggeredEventType {
+		actionTriggeredData := &keptn.ActionTriggeredEventData{}
+
+		err = eh.Event.DataAs(actionTriggeredData)
+		if err != nil {
+			eh.Logger.Error("Cannot parse incoming event: " + err.Error())
+			return err
+		}
+
+		if actionTriggeredData.Problem.PID == "" {
+			eh.Logger.Error("Cannot send DT problem comment: No problem ID is included in the event.")
+			return errors.New("cannot send DT problem comment: No problem ID is included in the event")
+		}
+
+		comment = "Keptn triggered action " + actionTriggeredData.Action.Action
+		if actionTriggeredData.Action.Description != "" {
+			comment = comment + ": " + actionTriggeredData.Action.Description
+		}
+		pid = actionTriggeredData.Problem.PID
+	} else if eh.Event.Type() == keptn.ActionFinishedEventType {
+		actionFinishedData := &keptn.ActionFinishedEventData{}
+
+		err = eh.Event.DataAs(actionFinishedData)
+		if err != nil {
+			eh.Logger.Error("Cannot parse incoming event: " + err.Error())
+			return err
+		}
+
+		if actionFinishedData.Problem.PID == "" {
+			eh.Logger.Error("Cannot send DT problem comment: No problem ID is included in the event.")
+			return errors.New("cannot send DT problem comment: No problem ID is included in the event")
+		}
+
+		comment = "Keptn finished execution of action"
+
+		pid = actionFinishedData.Problem.PID
+	} else {
+		return errors.New("invalid event type")
+	}
+
+	err = dynatraceHelper.SendProblemComment(pid, comment, dtCreds)
+
+	return nil
+}

--- a/pkg/event_handler/action_triggered.go
+++ b/pkg/event_handler/action_triggered.go
@@ -1,0 +1,57 @@
+package event_handler
+
+import (
+	"errors"
+
+	"github.com/keptn-contrib/dynatrace-service/pkg/lib"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	keptn "github.com/keptn/go-utils/pkg/lib"
+)
+
+type ActionTriggeredHandler struct {
+	Logger *keptn.Logger
+	Event  cloudevents.Event
+}
+
+func (eh ActionTriggeredHandler) HandleEvent() error {
+
+	keptnHandler, err := keptn.NewKeptn(&eh.Event, keptn.KeptnOpts{})
+	if err != nil {
+		eh.Logger.Error("could not initialize Keptn handler: " + err.Error())
+		return err
+	}
+	dynatraceHelper, err := lib.NewDynatraceHelper(keptnHandler)
+	if err != nil {
+		eh.Logger.Error("could not initialize Dynatrace helper: " + err.Error())
+		return err
+	}
+
+	keptnBase := &baseKeptnEvent{
+		project: keptnHandler.KeptnBase.Project,
+		stage:   keptnHandler.KeptnBase.Stage,
+		service: keptnHandler.KeptnBase.Service,
+	}
+
+	dynatraceConfig, _ := getDynatraceConfig(keptnBase, eh.Logger)
+
+	dtCreds := ""
+	if dynatraceConfig != nil {
+		dtCreds = dynatraceConfig.DtCreds
+	}
+
+	actionTriggeredData := &keptn.ActionTriggeredEventData{}
+
+	if actionTriggeredData.Problem.PID == "" {
+		eh.Logger.Error("Cannot send DT problem comment: No problem ID is included in the event.")
+		return errors.New("cannot send DT problem comment: No problem ID is included in the event")
+	}
+
+	comment := "Keptn triggering action " + actionTriggeredData.Action.Action
+	if actionTriggeredData.Action.Description != "" {
+		comment = comment + ": " + actionTriggeredData.Action.Description
+	}
+	err = dynatraceHelper.SendProblemComment(actionTriggeredData.Problem.PID, comment, dtCreds)
+
+	return nil
+}

--- a/pkg/event_handler/handler.go
+++ b/pkg/event_handler/handler.go
@@ -59,6 +59,10 @@ func NewEventHandler(event cloudevents.Event, logger *keptn.Logger) (DynatraceEv
 		return &CreateProjectEventHandler{Logger: logger, Event: event}, nil
 	case keptn.ProblemEventType:
 		return &ProblemEventHandler{Logger: logger, Event: event}, nil
+	case keptn.ActionTriggeredEventType:
+		return &ActionHandler{Logger: logger, Event: event}, nil
+	case keptn.ActionFinishedEventType:
+		return &ActionHandler{Logger: logger, Event: event}, nil
 	default:
 		return &CDEventHandler{Logger: logger, Event: event}, nil
 	}

--- a/pkg/lib/problem_comment.go
+++ b/pkg/lib/problem_comment.go
@@ -4,7 +4,11 @@ import "encoding/json"
 
 func (dt *DynatraceHelper) SendProblemComment(problemID string, comment string, dynatraceSecretName string) error {
 	dtCommentPayload := map[string]string{"comment": comment, "user": "keptn", "context": "keptn-remediation"}
-	jsonPayload, _ := json.Marshal(dtCommentPayload)
+	jsonPayload, err := json.Marshal(dtCommentPayload)
+
+	if err != nil {
+		return err
+	}
 
 	dt.Logger.Info("Sending problem event: " + string(jsonPayload))
 

--- a/pkg/lib/problem_comment.go
+++ b/pkg/lib/problem_comment.go
@@ -1,0 +1,18 @@
+package lib
+
+import "encoding/json"
+
+func (dt *DynatraceHelper) SendProblemComment(problemID string, comment string, dynatraceSecretName string) error {
+	dtCommentPayload := map[string]string{"comment": comment, "user": "keptn", "context": "keptn-remediation"}
+	jsonPayload, _ := json.Marshal(dtCommentPayload)
+
+	dt.Logger.Info("Sending problem event: " + string(jsonPayload))
+
+	resp, err := dt.sendDynatraceAPIRequest(dynatraceSecretName, "/api/v1/problem/details/"+problemID+"/comments", "POST", string(jsonPayload))
+
+	dt.Logger.Info("Received response from Dynatrace API: " + resp)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test-events/action-finished.http
+++ b/test-events/action-finished.http
@@ -1,0 +1,46 @@
+# For a quick start check out our HTTP Requests collection (Tools|HTTP Client|Open HTTP Requests Collection) or
+# paste cURL into the file and request will be converted to HTTP Request format.
+#
+# Following HTTP Request Live Templates are available:
+# * 'gtrp' and 'gtr' create a GET request with or without query parameters;
+# * 'ptr' and 'ptrp' create a POST request with a simple or parameter-like body;
+# * 'mptr' and 'fptr' create a POST request to submit a form with a text or file field (multipart/form-data);
+
+POST http://localhost:8080/
+Accept: application/json
+Cache-Control: no-cache
+Content-Type: application/cloudevents+json
+
+{
+  "type": "sh.keptn.event.configuration.change",
+  "contenttype": "application/json",
+  "specversion": "0.2",
+  "source": "test-event",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "shkeptncontext": "08735340-6f9e-4b32-97ff-3b6c292bc509",
+  "data": {
+    "action": {
+      "result": "pass",
+      "status": "succeeded"
+    },
+    "problem": {
+      "ImpactedEntity": "carts-primary",
+      "PID": "93a5-3fas-a09d-8ckf",
+      "ProblemDetails": "Pod name",
+      "ProblemID": "762",
+      "ProblemTitle": "cpu_usage_sockshop_carts",
+      "State": "OPEN"
+    },
+    "project": "sockshop",
+    "stage": "staging",
+    "service": "carts",
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
+  }
+}
+
+###

--- a/test-events/action-triggered.http
+++ b/test-events/action-triggered.http
@@ -1,0 +1,50 @@
+# For a quick start check out our HTTP Requests collection (Tools|HTTP Client|Open HTTP Requests Collection) or
+# paste cURL into the file and request will be converted to HTTP Request format.
+#
+# Following HTTP Request Live Templates are available:
+# * 'gtrp' and 'gtr' create a GET request with or without query parameters;
+# * 'ptr' and 'ptrp' create a POST request with a simple or parameter-like body;
+# * 'mptr' and 'fptr' create a POST request to submit a form with a text or file field (multipart/form-data);
+
+POST http://localhost:8080/
+Accept: application/json
+Cache-Control: no-cache
+Content-Type: application/cloudevents+json
+
+{
+  "type": "sh.keptn.event.action.triggered",
+  "specversion": "0.2",
+  "source": "https://github.com/keptn/keptn/remediation-service",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "contenttype": "application/json",
+  "shkeptncontext": "08735340-6f9e-4b32-97ff-3b6c292bc509",
+  "data": {
+    "action": {
+      "name": "FeatureToggle",
+      "action": "toggle-feature",
+      "description": "toggle a feature",
+      "values": {
+        "EnableItemCache": "on"
+      }
+    },
+    "problem": {
+      "ImpactedEntity": "carts-primary",
+      "PID": "93a5-3fas-a09d-8ckf",
+      "ProblemDetails": "Pod name",
+      "ProblemID": "762",
+      "ProblemTitle": "cpu_usage_sockshop_carts",
+      "State": "OPEN"
+    },
+    "project": "sockshop",
+    "stage": "staging",
+    "service": "carts",
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
+  }
+}
+
+###


### PR DESCRIPTION
This PR closes [#1818](https://github.com/keptn/issues/1818)
The dynatrace-service now reacts to `action.triggered` and `action.finished` events, and - if those events contain a Dynatrace Problem ID - sends a comment to the referenced problem.