### PR TITLE
#150 updated DT operator version

### DIFF
--- a/pkg/lib/dynatrace.go
+++ b/pkg/lib/dynatrace.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const DefaultOperatorVersion = "v0.6.0"
+const DefaultOperatorVersion = "v0.8.0"
 const sliResourceURI = "dynatrace/sli.yaml"
 const Throughput = "throughput"
 const ErrorRate = "error_rate"


### PR DESCRIPTION
Closes #150 

In this PR, the dynatrace-service will deploy the version 0.8.0 of the dynatrace oneagent operator