### PR TITLE
Correct WebSocket URL to /websocket

### DIFF
--- a/deploy/manifests/dynatrace-service/dynatrace-service.yaml
+++ b/deploy/manifests/dynatrace-service/dynatrace-service.yaml
@@ -315,6 +315,8 @@ spec:
               memory: "256Mi"
               cpu: "200m"
           env:
+            - name: API_WEBSOCKET_URL
+              value: 'ws://api-service:8080/websocket'
             - name: EVENTBROKER
               value: 'http://event-broker.keptn.svc.cluster.local/keptn'
             - name: PLATFORM


### PR DESCRIPTION
This PR 
- corrects the WebSocket URL to /websocket
- refactors the WebSocket URL into an env-variable