### PR TITLE
Improved info message and update of release notes

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: keptn-dynatrace-service
       containers:
         - name: dynatrace-service
-          image: keptncontrib/dynatrace-service:0.7.1-patch-fix-ws-comm-20200716.1153
+          image: keptncontrib/dynatrace-service:0.7.1-13-g6c90fc1-dirty
           ports:
             - containerPort: 8080
           resources:

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: keptn-dynatrace-service
       containers:
         - name: dynatrace-service
-          image: keptncontrib/dynatrace-service:0.7.1-13-g6c90fc1-dirty
+          image: keptncontrib/dynatrace-service:0.7.1-patch-info-msg-20200717
           ports:
             - containerPort: 8080
           resources:

--- a/pkg/event_handler/configure_monitoring.go
+++ b/pkg/event_handler/configure_monitoring.go
@@ -97,15 +97,13 @@ func (eh ConfigureMonitoringEventHandler) configureMonitoring() error {
 	dtHelper.Logger = eh.Logger
 	eh.DTHelper = dtHelper
 
-	// Remove the installation
-	err = eh.DTHelper.EnsureDTIsInstalled()
+	err = eh.DTHelper.CheckDTIsInstalled()
 
 	if err != nil {
 		eh.Logger.Error("could not install Dynatrace: " + err.Error())
 		return err
 	}
 
-	// don't touch
 	err = eh.DTHelper.EnsureDTTaggingRulesAreSetUp()
 	if err != nil {
 		eh.Logger.Error("Could not set up tagging rules: " + err.Error())

--- a/pkg/lib/one_agent.go
+++ b/pkg/lib/one_agent.go
@@ -15,7 +15,7 @@ func (dt *DynatraceHelper) CheckDTIsInstalled() error {
 Dynatrace OneAgent Operator is not installed on cluster
 # ATTENTION # ------------------------------------------------------------------------------------
 The behavior has changed and Dynatrace OneAgent Operator will NOT be installed automatically.
-If you want to roll-out the OneAgent, please follow the instructions as provided here: 
+If you want to roll-out the Dynatrace OneAgent Operator: 
 1.) Please follow the instructions as provided here: 
     https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/
 2.) Then, re-deploy the dynatrace-service: 

--- a/pkg/lib/one_agent.go
+++ b/pkg/lib/one_agent.go
@@ -8,26 +8,22 @@ type dtOperatorReleaseInfo struct {
 	TagName string `json:"tag_name"`
 }
 
-func (dt *DynatraceHelper) EnsureDTIsInstalled() error {
-	if dt.isDynatraceDeployed() {
-		dt.Logger.Info("Dynatrace OneAgent Operator is installed on cluster")
-	} else {
-		dt.Logger.Info("Dynatrace OneAgent Operator is not installed on cluster")
-		dt.Logger.Info("# ATTENTION # ------------------------------------------------------------------------------------------")
-		dt.Logger.Info("The behavior has changed and Dynatrace OneAgent Operator will NOT be installed.")
-		dt.Logger.Info("If you want to roll-out the OneAgent, please follow the instructions as provided here: ")
-		dt.Logger.Info("https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/")
-		dt.Logger.Info("--------------------------------------------------------------------------------------------------------")
-	}
-	return nil
-}
-
-func (dt *DynatraceHelper) isDynatraceDeployed() bool {
+func (dt *DynatraceHelper) CheckDTIsInstalled() error {
 	_, err := dt.KubeApi.AppsV1().Deployments("dynatrace").Get("dynatrace-oneagent-operator", metav1.GetOptions{})
 	if err != nil {
-		dt.Logger.Error(err.Error())
-		return false
+		dt.Logger.Info(`
+Dynatrace OneAgent Operator is not installed on cluster
+# ATTENTION # ------------------------------------------------------------------------------------
+The behavior has changed and Dynatrace OneAgent Operator will NOT be installed automatically.
+If you want to roll-out the OneAgent, please follow the instructions as provided here: 
+1.) Please follow the instructions as provided here: 
+    https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/
+2.) Then, re-deploy the dynatrace-service: 
+    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-service/<VERSION>/deploy/service.yaml
+--------------------------------------------------------------------------------------------------`)
+	} else {
+		dt.Logger.Info("Dynatrace OneAgent Operator is installed on cluster")
 	}
-	return true
+	return nil
 }
 

--- a/pkg/lib/one_agent.go
+++ b/pkg/lib/one_agent.go
@@ -12,8 +12,12 @@ func (dt *DynatraceHelper) EnsureDTIsInstalled() error {
 	if dt.isDynatraceDeployed() {
 		dt.Logger.Info("Dynatrace OneAgent Operator is installed on cluster")
 	} else {
-		dt.Logger.Info("Dynatrace OneAgent Operator is not installed on cluster.")
-		dt.Logger.Info("Please follow the instructions as provided here: https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/")
+		dt.Logger.Info("Dynatrace OneAgent Operator is not installed on cluster")
+		dt.Logger.Info("# ATTENTION # ------------------------------------------------------------------------------------------")
+		dt.Logger.Info("The behavior has changed and Dynatrace OneAgent Operator will NOT be installed.")
+		dt.Logger.Info("If you want to roll-out the OneAgent, please follow the instructions as provided here: ")
+		dt.Logger.Info("https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/")
+		dt.Logger.Info("--------------------------------------------------------------------------------------------------------")
 	}
 	return nil
 }

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -4,7 +4,7 @@
 
 - Send problem comments when actions are triggered/finished [#142](https://github.com/keptn-contrib/dynatrace-service/pull/142)
 - Added problemUrl to problem payload [#144](https://github.com/keptn-contrib/dynatrace-service/pull/144)
-- Created und now uses RBAC objects [#145](https://github.com/keptn-contrib/dynatrace-service/pull/145)
+- Created and now uses RBAC objects [#145](https://github.com/keptn-contrib/dynatrace-service/pull/145)
 - Removed dependency from keptn-domain ConfigMap [#148](https://github.com/keptn-contrib/dynatrace-service/pull/148)
 - Removed the installation of Dynatrace OneAgent when configuring monitoring [#156](https://github.com/keptn-contrib/dynatrace-service/pull/156)
 

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,10 +1,16 @@
-# Release Notes 0.7.x
+# Release Notes 0.8.0
 
 ## New Features
 
+- Send problem comments when actions are triggered/finished [#142](https://github.com/keptn-contrib/dynatrace-service/pull/142)
+- Added problemUrl to problem payload [#144](https://github.com/keptn-contrib/dynatrace-service/pull/144)
+- Created und now uses RBAC objects [#145](https://github.com/keptn-contrib/dynatrace-service/pull/145)
+- Removed dependency from keptn-domain ConfigMap [#148](https://github.com/keptn-contrib/dynatrace-service/pull/148)
+- Removed the installation of Dynatrace OneAgent when configuring monitoring [#156](https://github.com/keptn-contrib/dynatrace-service/pull/156)
 
 ## Fixed Issues
 
+- Correct WebSocket URL to /websocket [#152](https://github.com/keptn-contrib/dynatrace-service/pull/152)
 
 ## Known Limitations
 


### PR DESCRIPTION
Help the user, when DT OneAgent is not installed: 

```
Dynatrace OneAgent Operator is not installed on cluster
# ATTENTION # ------------------------------------------------------------------------------------
The behavior has changed and Dynatrace OneAgent Operator will NOT be installed automatically.
If you want to roll-out the OneAgent, please follow the instructions as provided here:
1.) Please follow the instructions as provided here:
    https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/deploy-oneagent-k8/
2.) Then, re-deploy the dynatrace-service:
    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-service/<VERSION>/deploy/service.yaml  
--------------------------------------------------------------------------------------------------
```