### PR TITLE
#171 don't exit if API connection check goes wrong

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,9 +43,11 @@ func _main(args []string, env envConfig) int {
 		log.Fatalf("failed to get Keptn API credentials: %s", err.Error())
 	}
 
+	log.Printf("Verifying access to Keptn API at %s", keptnCredentials.ApiURL)
+
 	err = common.CheckKeptnConnection(keptnCredentials)
 	if err != nil {
-		log.Fatalf("failed to verify Keptn API connection: %s", err.Error())
+		log.Printf("Warning: Keptn API connection cannot be verified. This might be due to a no-loopback policy of your LoadBalancer. The endpoint might still be reachable from outside the cluster. %s", err.Error())
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Closes #171 
To avoid crashes as a consequence of a failed Keptn API connectivity check (which is bound to happen if the LoadBalancer used to expose the Keptn API), a warning message is printed in the logs instead of exiting.