### PR TITLE
Fix parsing of sync interval environment variable

### DIFF
--- a/pkg/lib/configuration.go
+++ b/pkg/lib/configuration.go
@@ -40,6 +40,24 @@ func IsServiceSyncEnabled() bool {
 	return readEnvAsBool("SYNCHRONIZE_DYNATRACE_SERVICES", false)
 }
 
+// GetServiceSyncInterval returns the number of seconds the service synchronizer should sleep between synchronization runs
+// if the environment variable is empty or cannot be parsed, a default sync interval is used
+func GetServiceSyncInterval() int {
+	const defaultSyncInterval = 300
+
+	intervalEnv := os.Getenv("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS")
+	if intervalEnv == "" {
+		return defaultSyncInterval
+	}
+
+	parseInt, err := strconv.ParseInt(intervalEnv, 10, 32)
+	if err != nil {
+		return defaultSyncInterval
+	}
+
+	return int(parseInt)
+}
+
 func readEnvAsBool(env string, fallbackValue bool) bool {
 	if b, err := strconv.ParseBool(os.Getenv(env)); err == nil {
 		return b

--- a/pkg/lib/configuration.go
+++ b/pkg/lib/configuration.go
@@ -3,6 +3,8 @@ package lib
 import (
 	"os"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // IsTaggingRulesGenerationEnabled returns whether tagging rules should be generated when configuring the monitoring
@@ -43,24 +45,55 @@ func IsServiceSyncEnabled() bool {
 // GetServiceSyncInterval returns the number of seconds the service synchronizer should sleep between synchronization runs
 // if the environment variable is empty or cannot be parsed, a default sync interval is used
 func GetServiceSyncInterval() int {
-	const defaultSyncInterval = 300
+	return readEnvAsInt("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS", 300)
+}
 
-	intervalEnv := os.Getenv("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS")
-	if intervalEnv == "" {
-		return defaultSyncInterval
+func readEnvAsBool(env string, defaultValue bool) bool {
+	envValue := os.Getenv(env)
+	if envValue == "" {
+		log.WithFields(
+			log.Fields{
+				"name":    env,
+				"default": defaultValue,
+			}).Info("Environment variable not set or empty. Using default value.")
+		return defaultValue
 	}
 
-	parseInt, err := strconv.ParseInt(intervalEnv, 10, 32)
+	boolValue, err := strconv.ParseBool(envValue)
 	if err != nil {
-		return defaultSyncInterval
+		log.WithError(err).WithFields(
+			log.Fields{
+				"name":    env,
+				"value":   envValue,
+				"default": defaultValue,
+			}).Error("Unable to parse environment variable. Using default value.")
+		return defaultValue
+	}
+
+	return boolValue
+}
+
+func readEnvAsInt(env string, defaultValue int) int {
+	envValue := os.Getenv(env)
+	if envValue == "" {
+		log.WithFields(
+			log.Fields{
+				"name":    env,
+				"default": defaultValue,
+			}).Info("Environment variable not set or empty. Using default value.")
+		return defaultValue
+	}
+
+	parseInt, err := strconv.ParseInt(envValue, 10, 32)
+	if err != nil {
+		log.WithError(err).WithFields(
+			log.Fields{
+				"name":    env,
+				"value":   envValue,
+				"default": defaultValue,
+			}).Error("Unable to parse environment variable. Using default value.")
+		return defaultValue
 	}
 
 	return int(parseInt)
-}
-
-func readEnvAsBool(env string, fallbackValue bool) bool {
-	if b, err := strconv.ParseBool(os.Getenv(env)); err == nil {
-		return b
-	}
-	return fallbackValue
 }

--- a/pkg/lib/service_sync.go
+++ b/pkg/lib/service_sync.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -22,7 +21,6 @@ import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
-const defaultSyncInterval = 300
 const defaultDTProjectName = "dynatrace"
 const defaultDTProjectStage = "quality-gate"
 const defaultSLOFile = `---
@@ -166,17 +164,7 @@ func ActivateServiceSynchronizer(c *credentials.CredentialManager) *serviceSynch
 }
 
 func (s *serviceSynchronizer) initializeSynchronizationTimer() {
-	var syncInterval int
-	intervalEnv := os.Getenv("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS")
-	if intervalEnv == "" {
-		syncInterval = defaultSyncInterval
-	}
-	parseInt, err := strconv.ParseInt(intervalEnv, 10, 32)
-	if err != nil {
-		s.logger.Error(fmt.Sprintf("Could not parse SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS with value %s, using %ds as default.", intervalEnv, defaultSyncInterval))
-		syncInterval = defaultSyncInterval
-	}
-	syncInterval = int(parseInt)
+	syncInterval := GetServiceSyncInterval()
 	s.logger.Info(fmt.Sprintf("Service Synchronizer will sync every %d seconds", syncInterval))
 	s.syncTimer = time.NewTicker(time.Duration(syncInterval) * time.Second)
 	go func() {


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

`lib.synchronizeServices()` was partially ignoring parsing errors from the `SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS` environment variable. This PR addresses that and moves the associated code from `pkg/lib/service_sync.go` to `pkg/lib/configuration.go` where the rest of the code accessing environment variables is located.