### PR TITLE
Updated configuration for upcoming Keptn 0.8.4 distributor

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "dynatrace-service.selectorLabels" . | nindent 8 }}
+        {{- include "dynatrace-service.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -127,6 +127,26 @@ spec:
             - name: HTTP_SSL_VERIFY
               value: "{{ .Values.remoteControlPlane.api.apiValidateTls | default "true" }}"
             {{- end }}
+            - name: K8S_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -127,6 +127,11 @@ spec:
             - name: HTTP_SSL_VERIFY
               value: "{{ .Values.remoteControlPlane.api.apiValidateTls | default "true" }}"
             {{- end }}
+            - name: VERSION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
             - name: K8S_DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,7 +26,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.8.2"                             # Container Tag
+    tag: "0.8.4"                             # Container Tag
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode

--- a/deploy/service-no-dt-setup.yaml
+++ b/deploy/service-no-dt-setup.yaml
@@ -52,6 +52,8 @@ spec:
     metadata:
       labels:
         run: dynatrace-service
+        app.kubernetes.io/name: dynatrace-service
+        app.kubernetes.io/version: latest
     spec:
       securityContext:
         fsGroup: 65532
@@ -120,6 +122,31 @@ spec:
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+            - name: LOCATION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
+            - name: K8S_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532

--- a/deploy/service-no-dt-setup.yaml
+++ b/deploy/service-no-dt-setup.yaml
@@ -105,7 +105,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: keptn/distributor:0.8.2
+          image: keptn/distributor:0.8.4
           ports:
             - containerPort: 8080
           resources:
@@ -122,11 +122,11 @@ spec:
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
-            - name: LOCATION
+            - name: VERSION
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
             - name: K8S_DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -52,6 +52,8 @@ spec:
     metadata:
       labels:
         run: dynatrace-service
+        app.kubernetes.io/name: dynatrace-service
+        app.kubernetes.io/version: latest
     spec:
       securityContext:
         fsGroup: 65532
@@ -103,7 +105,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: keptn/distributor:0.8.2
+          image: keptn/distributor:0.8.4
           ports:
             - containerPort: 8080
           resources:
@@ -120,6 +122,36 @@ spec:
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+            - name: VERSION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
+            - name: LOCATION
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
+            - name: K8S_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -127,11 +127,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
-            - name: LOCATION
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
             - name: K8S_DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
In Keptn 0.8.4, the distributor will be extended with the functionality of registering itself as a Keptn uniform integration at the Keptn's Uniform API.

Related Video with short Tutorial (part of community meeting on June 17th): https://youtu.be/oZlf1v5qUvc?t=436

To enable this feature, the following changes need to be made:

First, the image of the `distributor` container of the deployment needs to be set to `keptn/distributor:0.8.4`:

```
        - name: distributor
              image: keptn/distributor:0.8.4
```

Second, the following environment variables have to be added to the `distributor` container:

```
            - name: VERSION
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
            - name: K8S_DEPLOYMENT_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
            - name: K8S_POD_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.name
            - name: K8S_NAMESPACE
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
            - name: K8S_NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
```

Last but not least, ensure that the labels `app.kubernetes.io/version` and `app.kubernetes.name` are available under `spec.template.metadata.labels` in the K8s deployment:

```
        app.kubernetes.io/name: dynatrace-service
        app.kubernetes.io/version: 0.14.1
```

The complete deployment.yaml of the service should look as follows:

```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: keptn-dynatrace-service
  labels:
    "app": "keptn"

---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: keptn-dynatrace-service-secrets
  labels:
    "app": "keptn"
rules:
  - apiGroups:
      - ""
    resources:
      - secrets
    verbs:
      - get
      - list
      - watch

---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: keptn-dynatrace-service-secrets
  labels:
    "app": "keptn"
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: keptn-dynatrace-service-secrets
subjects:
  - kind: ServiceAccount
    name: keptn-dynatrace-service

---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dynatrace-service
spec:
  selector:
    matchLabels:
      run: dynatrace-service
  replicas: 1
  template:
    metadata:
      labels:
        run: dynatrace-service
        app.kubernetes.io/name: dynatrace-service             // this label is required by the registration feature
        app.kubernetes.io/version: latest                                // this label is required by the registration feature
    spec:
      securityContext:
        fsGroup: 65532
      serviceAccountName: keptn-dynatrace-service
      containers:
        - name: dynatrace-service
          image: keptncontrib/dynatrace-service:latest
          ports:
            - containerPort: 8080
          resources:
            requests:
              memory: "32Mi"
              cpu: "100m"
            limits:
              memory: "256Mi"
              cpu: "200m"
          env:
            - name: DATASTORE
              value: 'http://mongodb-datastore:8080'
            - name: CONFIGURATION_SERVICE
              value: 'http://configuration-service:8080'
            - name: SHIPYARD_CONTROLLER
              value: 'http://shipyard-controller:8080'
            - name: PLATFORM
              value: kubernetes
            - name: POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: GENERATE_TAGGING_RULES
              value: 'false'
            - name: GENERATE_PROBLEM_NOTIFICATIONS
              value: 'false'
            - name: GENERATE_MANAGEMENT_ZONES
              value: 'false'
            - name: GENERATE_DASHBOARDS
              value: 'false'
            - name: GENERATE_METRIC_EVENTS
              value: 'false'
            - name: SYNCHRONIZE_DYNATRACE_SERVICES
              value: 'true'
            - name: SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS
              value: '60'
            - name: HTTP_SSL_VERIFY
              value: 'true'
          securityContext:
            runAsNonRoot: true
            runAsUser: 65532
            readOnlyRootFilesystem: true
            allowPrivilegeEscalation: false
        - name: distributor
          image: keptn/distributor:0.8.4
          ports:
            - containerPort: 8080
          resources:
            requests:
              memory: "32Mi"
              cpu: "50m"
            limits:
              memory: "128Mi"
              cpu: "500m"
          env:
            - name: PUBSUB_URL
              value: 'nats://keptn-nats-cluster'
            - name: PUBSUB_TOPIC
              value: 'sh.keptn.>'
            - name: PUBSUB_RECIPIENT
              value: '127.0.0.1'
            - name: VERSION
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
            - name: K8S_DEPLOYMENT_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: 'metadata.labels[''app.kubernetes.io/name'']'
            - name: K8S_POD_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.name
            - name: K8S_NAMESPACE
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
            - name: K8S_NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
          securityContext:
            runAsNonRoot: true
            runAsUser: 65532
            readOnlyRootFilesystem: true
            allowPrivilegeEscalation: false

---
apiVersion: v1
kind: Service
metadata:
  name: dynatrace-service
  labels:
    run: dynatrace-service
spec:
  ports:
    - port: 8080
      protocol: TCP
  selector:
    run: dynatrace-service
```



❗ Note that this PR should only be merged once Keptn 0.8.4 has been released officially


Once this change has been released and installed in the Kubernetes cluster, the integration/service should be visible in Keptn's Bridge Uniform screen:
![image](https://user-images.githubusercontent.com/56065213/122389276-12e23200-cf71-11eb-955d-a636cb42211b.png)


Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>