### PR TITLE
Use logrus as global logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/keptn/go-utils v0.8.4-0.20210512062520-b524ddf69d98
 	github.com/matryer/moq v0.2.1 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -352,6 +354,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=

--- a/pkg/adapter/mock/dynatrace_config_mock.go
+++ b/pkg/adapter/mock/dynatrace_config_mock.go
@@ -6,7 +6,6 @@ package adapter_mock
 import (
 	"github.com/keptn-contrib/dynatrace-service/pkg/adapter"
 	"github.com/keptn-contrib/dynatrace-service/pkg/config"
-	"github.com/keptn/go-utils/pkg/lib/keptn"
 	"sync"
 )
 
@@ -27,7 +26,7 @@ import (
 // 	}
 type DynatraceConfigGetterInterfaceMock struct {
 	// GetDynatraceConfigFunc mocks the GetDynatraceConfig method.
-	GetDynatraceConfigFunc func(event adapter.EventContentAdapter, logger keptn.LoggerInterface) (*config.DynatraceConfigFile, error)
+	GetDynatraceConfigFunc func(event adapter.EventContentAdapter) (*config.DynatraceConfigFile, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -35,41 +34,35 @@ type DynatraceConfigGetterInterfaceMock struct {
 		GetDynatraceConfig []struct {
 			// Event is the event argument value.
 			Event adapter.EventContentAdapter
-			// Logger is the logger argument value.
-			Logger keptn.LoggerInterface
 		}
 	}
 	lockGetDynatraceConfig sync.RWMutex
 }
 
 // GetDynatraceConfig calls GetDynatraceConfigFunc.
-func (mock *DynatraceConfigGetterInterfaceMock) GetDynatraceConfig(event adapter.EventContentAdapter, logger keptn.LoggerInterface) (*config.DynatraceConfigFile, error) {
+func (mock *DynatraceConfigGetterInterfaceMock) GetDynatraceConfig(event adapter.EventContentAdapter) (*config.DynatraceConfigFile, error) {
 	if mock.GetDynatraceConfigFunc == nil {
 		panic("DynatraceConfigGetterInterfaceMock.GetDynatraceConfigFunc: method is nil but DynatraceConfigGetterInterface.GetDynatraceConfig was just called")
 	}
 	callInfo := struct {
-		Event  adapter.EventContentAdapter
-		Logger keptn.LoggerInterface
+		Event adapter.EventContentAdapter
 	}{
-		Event:  event,
-		Logger: logger,
+		Event: event,
 	}
 	mock.lockGetDynatraceConfig.Lock()
 	mock.calls.GetDynatraceConfig = append(mock.calls.GetDynatraceConfig, callInfo)
 	mock.lockGetDynatraceConfig.Unlock()
-	return mock.GetDynatraceConfigFunc(event, logger)
+	return mock.GetDynatraceConfigFunc(event)
 }
 
 // GetDynatraceConfigCalls gets all the calls that were made to GetDynatraceConfig.
 // Check the length with:
 //     len(mockedDynatraceConfigGetterInterface.GetDynatraceConfigCalls())
 func (mock *DynatraceConfigGetterInterfaceMock) GetDynatraceConfigCalls() []struct {
-	Event  adapter.EventContentAdapter
-	Logger keptn.LoggerInterface
+	Event adapter.EventContentAdapter
 } {
 	var calls []struct {
-		Event  adapter.EventContentAdapter
-		Logger keptn.LoggerInterface
+		Event adapter.EventContentAdapter
 	}
 	mock.lockGetDynatraceConfig.RLock()
 	calls = mock.calls.GetDynatraceConfig

--- a/pkg/event_handler/create_project.go
+++ b/pkg/event_handler/create_project.go
@@ -2,8 +2,11 @@ package event_handler
 
 import (
 	"encoding/base64"
+
 	"github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/keptn-contrib/dynatrace-service/pkg/adapter"
 	"github.com/keptn-contrib/dynatrace-service/pkg/credentials"
@@ -14,7 +17,6 @@ import (
 )
 
 type CreateProjectEventHandler struct {
-	Logger         keptn.LoggerInterface
 	Event          cloudevents.Event
 	dtConfigGetter adapter.DynatraceConfigGetterInterface
 }
@@ -26,44 +28,44 @@ func (eh CreateProjectEventHandler) HandleEvent() error {
 	e := &keptnv2.ProjectCreateFinishedEventData{}
 	err := eh.Event.DataAs(e)
 	if err != nil {
-		eh.Logger.Error("Could not parse event payload: " + err.Error())
+		log.WithError(err).Error("Could not parse event payload")
 		return err
 	}
 
 	shipyard := &keptnv2.Shipyard{}
 	decodedShipyard, err := base64.StdEncoding.DecodeString(e.CreatedProject.Shipyard)
 	if err != nil {
-		eh.Logger.Error("Could not decode shipyard: " + err.Error())
+		log.WithError(err).Error("Could not decode shipyard")
 	}
 	err = yaml.Unmarshal(decodedShipyard, shipyard)
 	if err != nil {
-		eh.Logger.Error("Could not parse shipyard: " + err.Error())
+		log.WithError(err).Error("Could not parse shipyard")
 	}
 
 	keptnHandler, err := keptnv2.NewKeptn(&eh.Event, keptn.KeptnOpts{})
 	if err != nil {
-		eh.Logger.Error("could not create Keptn handler: " + err.Error())
+		log.WithError(err).Error("Could not create Keptn handler")
 	}
 
 	keptnEvent := adapter.NewProjectCreateAdapter(*e, keptnHandler.KeptnContext, eh.Event.Source())
 
-	dynatraceConfig, err := eh.dtConfigGetter.GetDynatraceConfig(keptnEvent, eh.Logger)
+	dynatraceConfig, err := eh.dtConfigGetter.GetDynatraceConfig(keptnEvent)
 	if err != nil {
-		eh.Logger.Error("failed to load Dynatrace config: " + err.Error())
+		log.WithError(err).Error("failed to load Dynatrace config")
 		return err
 	}
 	creds, err := credentials.GetDynatraceCredentials(dynatraceConfig)
 	if err != nil {
-		eh.Logger.Error("failed to load Dynatrace credentials: " + err.Error())
+		log.WithError(err).Error("Failed to load Dynatrace credentials")
 		return err
 	}
-	dtHelper := lib.NewDynatraceHelper(keptnHandler, creds, eh.Logger)
+	dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
 	_, err = dtHelper.ConfigureMonitoring(e.Project, shipyard)
 	if err != nil {
 		return err
 	}
 
-	eh.Logger.Info("Dynatrace Monitoring setup done")
+	log.Info("Dynatrace Monitoring setup done")
 	return nil
 }

--- a/pkg/event_handler/handler.go
+++ b/pkg/event_handler/handler.go
@@ -4,31 +4,31 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/pkg/adapter"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
-	keptn "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	log "github.com/sirupsen/logrus"
 )
 
 type DynatraceEventHandler interface {
 	HandleEvent() error
 }
 
-func NewEventHandler(event cloudevents.Event, logger *keptn.Logger) (DynatraceEventHandler, error) {
-	logger.Debug("Received event: " + event.Type())
+func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
+	log.WithField("eventType", event.Type()).Debug("Received event")
 	dtConfigGetter := &adapter.DynatraceConfigGetter{}
 	switch event.Type() {
 	case keptnevents.ConfigureMonitoringEventType:
-		return &ConfigureMonitoringEventHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &ConfigureMonitoringEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetFinishedEventType(keptnv2.ProjectCreateTaskName):
-		return &CreateProjectEventHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &CreateProjectEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnevents.ProblemEventType:
-		return &ProblemEventHandler{Logger: logger, Event: event}, nil
+		return &ProblemEventHandler{Event: event}, nil
 	case keptnv2.GetTriggeredEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetStartedEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetFinishedEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	default:
-		return &CDEventHandler{Logger: logger, Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &CDEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	}
 }

--- a/pkg/event_handler/helper.go
+++ b/pkg/event_handler/helper.go
@@ -3,7 +3,6 @@ package event_handler
 import (
 	"github.com/keptn-contrib/dynatrace-service/pkg/adapter"
 	"github.com/keptn-contrib/dynatrace-service/pkg/config"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 )
 
 type dtConfigurationEvent struct {
@@ -53,7 +52,7 @@ type dtAnnotationEvent struct {
 /**
  * Changes in #115_116: Parse Tags from dynatrace.conf.yaml and only fall back to default behavior if it doesnt exist
  */
-func createAttachRules(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile, logger *keptncommon.Logger) config.DtAttachRules {
+func createAttachRules(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) config.DtAttachRules {
 	if dynatraceConfig != nil && dynatraceConfig.AttachRules != nil {
 		return *dynatraceConfig.AttachRules
 	}
@@ -89,7 +88,7 @@ func createAttachRules(a adapter.EventContentAdapter, dynatraceConfig *config.Dy
 /**
  * Change with #115_116: parse labels and move them into custom properties
  */
-func createCustomProperties(a adapter.EventContentAdapter, logger *keptncommon.Logger) map[string]string {
+func createCustomProperties(a adapter.EventContentAdapter) map[string]string {
 	// TODO: AG - parse labels and push them through
 
 	// var customProperties dtCustomProperties
@@ -120,7 +119,7 @@ func createCustomProperties(a adapter.EventContentAdapter, logger *keptncommon.L
 }
 
 // createInfoEvent creates a new Info event
-func createInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile, logger *keptncommon.Logger) dtInfoEvent {
+func createInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtInfoEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
 	var ie dtInfoEvent
@@ -130,18 +129,18 @@ func createInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.Dyna
 	ie.Description = a.GetLabels()["description"]
 
 	// now we create our attach rules
-	ar := createAttachRules(a, dynatraceConfig, logger)
+	ar := createAttachRules(a, dynatraceConfig)
 	ie.AttachRules = ar
 
 	// and add the rest of the labels and info as custom properties
-	customProperties := createCustomProperties(a, logger)
+	customProperties := createCustomProperties(a)
 	ie.CustomProperties = customProperties
 
 	return ie
 }
 
 // createAnnotationEvent creates a Dynatrace ANNOTATION event
-func createAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile, logger *keptncommon.Logger) dtAnnotationEvent {
+func createAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtAnnotationEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
 	var ie dtAnnotationEvent
@@ -151,11 +150,11 @@ func createAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *confi
 	ie.AnnotationDescription = a.GetLabels()["description"]
 
 	// now we create our attach rules
-	ar := createAttachRules(a, dynatraceConfig, logger)
+	ar := createAttachRules(a, dynatraceConfig)
 	ie.AttachRules = ar
 
 	// and add the rest of the labels and info as custom properties
-	customProperties := createCustomProperties(a, logger)
+	customProperties := createCustomProperties(a)
 	ie.CustomProperties = customProperties
 
 	return ie
@@ -169,7 +168,7 @@ func getValueFromLabels(a adapter.EventContentAdapter, key string, defaultValue 
 	return defaultValue
 }
 
-func createDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile, logger *keptncommon.Logger) dtDeploymentEvent {
+func createDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtDeploymentEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
 	var de dtDeploymentEvent
@@ -182,18 +181,18 @@ func createDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *confi
 	de.RemediationAction = getValueFromLabels(a, "remediationAction", "")
 
 	// now we create our attach rules
-	ar := createAttachRules(a, dynatraceConfig, logger)
+	ar := createAttachRules(a, dynatraceConfig)
 	de.AttachRules = ar
 
 	// and add the rest of the labels and info as custom properties
 	// TODO: event.Project, event.Stage, event.Service, event.TestStrategy, event.Image, event.Tag, event.Labels, keptnContext
-	customProperties := createCustomProperties(a, logger)
+	customProperties := createCustomProperties(a)
 	de.CustomProperties = customProperties
 
 	return de
 }
 
-func createConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile, logger *keptncommon.Logger) dtConfigurationEvent {
+func createConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtConfigurationEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
 	var de dtConfigurationEvent
@@ -201,12 +200,12 @@ func createConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *co
 	de.Source = "Keptn dynatrace-service"
 
 	// now we create our attach rules
-	ar := createAttachRules(a, dynatraceConfig, logger)
+	ar := createAttachRules(a, dynatraceConfig)
 	de.AttachRules = ar
 
 	// and add the rest of the labels and info as custom properties
 	// TODO: event.Project, event.Stage, event.Service, event.TestStrategy, event.Image, event.Tag, event.Labels, keptnContext
-	customProperties := createCustomProperties(a, logger)
+	customProperties := createCustomProperties(a)
 	de.CustomProperties = customProperties
 
 	return de

--- a/pkg/lib/dynatrace.go
+++ b/pkg/lib/dynatrace.go
@@ -9,7 +9,8 @@ import (
 	"os"
 	"strings"
 
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
+	log "github.com/sirupsen/logrus"
+
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
 	"github.com/keptn-contrib/dynatrace-service/pkg/common"
@@ -43,7 +44,6 @@ type Values struct {
 
 type DynatraceHelper struct {
 	DynatraceCreds     *credentials.DTCredentials
-	Logger             keptncommon.LoggerInterface
 	OperatorTag        string
 	KeptnHandler       *keptnv2.Keptn
 	KeptnBridge        string
@@ -72,11 +72,10 @@ type ConfiguredEntities struct {
 }
 
 // NewDynatraceHelper creates a new DynatraceHelper
-func NewDynatraceHelper(keptnHandler *keptnv2.Keptn, dynatraceCreds *credentials.DTCredentials, logger keptncommon.LoggerInterface) *DynatraceHelper {
+func NewDynatraceHelper(keptnHandler *keptnv2.Keptn, dynatraceCreds *credentials.DTCredentials) *DynatraceHelper {
 	return &DynatraceHelper{
 		DynatraceCreds: dynatraceCreds,
 		KeptnHandler:   keptnHandler,
-		Logger:         logger,
 	}
 }
 
@@ -137,8 +136,11 @@ func shouldCreateMetricEvents(stage keptnv2.Stage) bool {
 func (dt *DynatraceHelper) sendDynatraceAPIRequest(apiPath string, method string, body []byte) (string, error) {
 
 	if common.RunLocal || common.RunLocalTest {
-		dt.Logger.Info("Dynatrace.sendDynatraceAPIRequest(RUNLOCAL) - not sending event to " +
-			dt.DynatraceCreds.Tenant + "). Here is the payload: " + string(body))
+		log.WithFields(
+			log.Fields{
+				"tenant": dt.DynatraceCreds.Tenant,
+				"body":   string(body),
+			}).Info("Dynatrace.sendDynatraceAPIRequest(RUNLOCAL) - not sending event to tenant")
 		return "", nil
 	}
 

--- a/pkg/lib/dynatrace_events.go
+++ b/pkg/lib/dynatrace_events.go
@@ -2,25 +2,26 @@ package lib
 
 import (
 	"encoding/json"
-	"fmt"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Sends an event to the Dynatrace events API
 func (dt *DynatraceHelper) SendEvent(dtEvent interface{}) {
-	dt.Logger.Info("Sending event to Dynatrace API")
+	log.Info("Sending event to Dynatrace API")
 
 	jsonString, err := json.Marshal(dtEvent)
 
 	if err != nil {
-		dt.Logger.Error("Error while generating Dynatrace API Request payload.")
+		log.WithError(err).Error("Error while generating Dynatrace API Request payload.")
 		return
 	}
 
 	body, err := dt.sendDynatraceAPIRequest("/api/v1/events", "POST", jsonString)
 	if err != nil {
-		dt.Logger.Error(fmt.Sprintf("failed sending Dynatrace API request: %v", err))
+		log.WithError(err).Error("Failed sending Dynatrace API request")
 	} else {
-		dt.Logger.Debug(fmt.Sprintf("Dynatrace API has accepted the event. Response: %s", body))
+		log.WithField("body", body).Debug("Dynatrace API has accepted the event")
 	}
 
 }

--- a/pkg/lib/dynatrace_test.go
+++ b/pkg/lib/dynatrace_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/keptn-contrib/dynatrace-service/pkg/credentials"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
@@ -30,7 +29,6 @@ func TestDynatraceHelper_createClient(t *testing.T) {
 	}
 	type fields struct {
 		DynatraceCreds     *credentials.DTCredentials
-		Logger             keptncommon.LoggerInterface
 		OperatorTag        string
 		KeptnHandler       *keptnv2.Keptn
 		KeptnBridge        string
@@ -62,7 +60,6 @@ func TestDynatraceHelper_createClient(t *testing.T) {
 					Tenant:   mockTenant,
 					ApiToken: "",
 				},
-				Logger: keptncommon.NewLogger("", "", ""),
 			},
 			args: args{
 				req: mockReq,
@@ -94,7 +91,6 @@ func TestDynatraceHelper_createClient(t *testing.T) {
 
 			dt := &DynatraceHelper{
 				DynatraceCreds:     tt.fields.DynatraceCreds,
-				Logger:             tt.fields.Logger,
 				OperatorTag:        tt.fields.OperatorTag,
 				KeptnHandler:       tt.fields.KeptnHandler,
 				KeptnBridge:        tt.fields.KeptnBridge,

--- a/pkg/lib/management_zones.go
+++ b/pkg/lib/management_zones.go
@@ -3,7 +3,9 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
+
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	log "github.com/sirupsen/logrus"
 )
 
 // CreateManagementZones creates a new management zone for the project
@@ -29,13 +31,13 @@ func (dt *DynatraceHelper) CreateManagementZones(project string, shipyard keptnv
 
 			if err != nil {
 				// Error occurred but continue
-				msg := "failed to create management zone: " + err.Error()
-				dt.Logger.Error(msg)
+
+				log.WithError(err).Error("Failed to create management zone")
 
 				dt.configuredEntities.ManagementZones = append(dt.configuredEntities.ManagementZones, ConfigResult{
 					Name:    "Keptn: " + project,
 					Success: false,
-					Message: msg,
+					Message: "failed to create management zone: " + err.Error(),
 				})
 			} else {
 				dt.configuredEntities.ManagementZones = append(dt.configuredEntities.ManagementZones, ConfigResult{
@@ -44,6 +46,7 @@ func (dt *DynatraceHelper) CreateManagementZones(project string, shipyard keptnv
 				})
 			}
 		} else {
+			// TODO: Check what happens to this error?
 			// Error occurred but continue
 			fmt.Errorf("failed to marshal management zone: %v", err)
 		}
@@ -68,12 +71,11 @@ func (dt *DynatraceHelper) CreateManagementZones(project string, shipyard keptnv
 			mzPayload, _ := json.Marshal(managementZone)
 			_, err := dt.sendDynatraceAPIRequest("/api/config/v1/managementZones", "POST", mzPayload)
 			if err != nil {
-				msg := "Could not create management zone: " + err.Error()
-				dt.Logger.Error(msg)
+				log.WithError(err).Error("Could not create management zone")
 				dt.configuredEntities.ManagementZones = append(dt.configuredEntities.ManagementZones, ConfigResult{
 					Name:    managementZone.Name,
 					Success: false,
-					Message: msg,
+					Message: "Could not create management zone: " + err.Error(),
 				})
 			} else {
 				dt.configuredEntities.ManagementZones = append(dt.configuredEntities.ManagementZones, ConfigResult{
@@ -100,14 +102,14 @@ func getManagementZoneNameForStage(project string, stage string) string {
 func (dt *DynatraceHelper) getManagementZones() []Values {
 	response, err := dt.sendDynatraceAPIRequest("/api/config/v1/managementZones", "GET", nil)
 	if err != nil {
-		dt.Logger.Error("failed to retrieve management zones: " + err.Error())
+		log.WithError(err).Error("Failed to retrieve management zones")
 		return nil
 	}
 	mzs := &DTAPIListResponse{}
 
 	err = json.Unmarshal([]byte(response), mzs)
 	if err != nil {
-		dt.Logger.Error("failed to parse management zones list: " + err.Error())
+		log.WithError(err).Error("Failed to parse management zones list")
 		return nil
 	}
 	return mzs.Values

--- a/pkg/lib/problem_comment.go
+++ b/pkg/lib/problem_comment.go
@@ -1,6 +1,10 @@
 package lib
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	log "github.com/sirupsen/logrus"
+)
 
 // SendProblemComment sends a commont on a DT problem
 func (dt *DynatraceHelper) SendProblemComment(problemID string, comment string) error {
@@ -11,11 +15,11 @@ func (dt *DynatraceHelper) SendProblemComment(problemID string, comment string) 
 		return err
 	}
 
-	dt.Logger.Info("Sending problem event: " + string(jsonPayload))
+	log.WithField("jsonPayload", jsonPayload).Info("Sending problem event")
 
 	resp, err := dt.sendDynatraceAPIRequest("/api/v1/problem/details/"+problemID+"/comments", "POST", jsonPayload)
 
-	dt.Logger.Info("Received response from Dynatrace API: " + resp)
+	log.WithField("response", resp).Info("Received response from Dynatrace API")
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/service_sync.go
+++ b/pkg/lib/service_sync.go
@@ -20,6 +20,7 @@ import (
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	log "github.com/sirupsen/logrus"
 )
 
 const defaultSyncInterval = 300
@@ -116,7 +117,6 @@ func (initSyncEventAdapter) GetLabels() map[string]string {
 }
 
 type serviceSynchronizer struct {
-	logger            keptncommon.LoggerInterface
 	projectsAPI       *keptnapi.ProjectHandler
 	servicesAPI       *keptnapi.ServiceHandler
 	resourcesAPI      *keptnapi.ResourceHandler
@@ -139,21 +139,20 @@ func ActivateServiceSynchronizer(c *credentials.CredentialManager) *serviceSynch
 	if serviceSynchronizerInstance == nil {
 
 		encodedDefaultSLOFile = b64.StdEncoding.EncodeToString([]byte(defaultSLOFile))
-		logger := keptncommon.NewLogger("", "", "dynatrace-service")
 		serviceSynchronizerInstance = &serviceSynchronizer{
-			logger:            logger,
 			credentialManager: c,
 		}
 
 		serviceSynchronizerInstance.dtConfigGetter = &adapter.DynatraceConfigGetter{}
-		serviceSynchronizerInstance.DTHelper = NewDynatraceHelper(nil, nil, logger)
+		serviceSynchronizerInstance.DTHelper = NewDynatraceHelper(nil, nil)
 
-		serviceSynchronizerInstance.logger.Debug("Initializing Service Synchronizer")
 		configServiceBaseURL := common.GetConfigurationServiceURL()
 		shipyardControllerBaseURL := common.GetShipyardControllerURL()
-
-		serviceSynchronizerInstance.logger.Debug("Service Synchronizer uses configuration service URL: " + configServiceBaseURL)
-		serviceSynchronizerInstance.logger.Debug("Service Synchronizer uses shipyard controller URL: " + shipyardControllerBaseURL)
+		log.WithFields(
+			log.Fields{
+				"configServiceBaseURL":      configServiceBaseURL,
+				"shipyardControllerBaseURL": shipyardControllerBaseURL,
+			}).Debug("Initializing Service Synchronizer")
 
 		serviceSynchronizerInstance.projectsAPI = keptnapi.NewProjectHandler(shipyardControllerBaseURL)
 		serviceSynchronizerInstance.servicesAPI = keptnapi.NewServiceHandler(shipyardControllerBaseURL)
@@ -173,40 +172,45 @@ func (s *serviceSynchronizer) initializeSynchronizationTimer() {
 	}
 	parseInt, err := strconv.ParseInt(intervalEnv, 10, 32)
 	if err != nil {
-		s.logger.Error(fmt.Sprintf("Could not parse SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS with value %s, using %ds as default.", intervalEnv, defaultSyncInterval))
+		log.WithError(err).WithFields(
+			log.Fields{
+				"name":    "SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS",
+				"value":   intervalEnv,
+				"default": defaultSyncInterval,
+			}).Error("Could not parse environment variable. Using default.")
 		syncInterval = defaultSyncInterval
 	}
 	syncInterval = int(parseInt)
-	s.logger.Info(fmt.Sprintf("Service Synchronizer will sync every %d seconds", syncInterval))
+	log.WithField("syncInterval", syncInterval).Info("Service Synchronizer will sync periodically")
 	s.syncTimer = time.NewTicker(time.Duration(syncInterval) * time.Second)
 	go func() {
 		for {
 			s.synchronizeServices()
 			<-s.syncTimer.C
-			s.logger.Info(fmt.Sprintf("%d seconds have passed. Synchronizing services", syncInterval))
+			log.WithField("delaySeconds", syncInterval).Info("Synchronizing services")
 		}
 	}()
 }
 
 func (s *serviceSynchronizer) synchronizeServices() {
 	if err := s.establishDTAPIConnection(); err != nil {
-		s.logger.Error(fmt.Sprintf("Could not establish Dynatrace API connection: %s", err.Error()))
+		log.WithError(err).Error("Could not establish Dynatrace API connection")
 		return
 	}
 
-	s.logger.Info("Fetching existing services in project " + defaultDTProjectName + " ")
+	log.WithField("project", defaultDTProjectName).Info("Fetching existing services in project")
 	if err := s.fetchExistingServices(); err != nil {
-		s.logger.Error(fmt.Sprintf("Could not fetch existing services in project: %s", err.Error()))
+		log.WithError(err).Error("Could not fetch existing services")
 		return
 	}
 
-	s.logger.Info("Fetching service entities with tags 'keptn_managed' and 'keptn_service'")
+	log.Info("Fetching service entities with tags 'keptn_managed' and 'keptn_service'")
 	nextPageKey := ""
 	pageSize := 50
 	for {
 		entitiesResponse, err := s.fetchKeptnManagedServicesFromDynatrace(nextPageKey, pageSize)
 		if err != nil {
-			s.logger.Error(fmt.Sprintf("Fetching service entities with tags 'keptn_managed' and 'keptn_service': %s", err))
+			log.WithError(err).Error("Error fetching keptn managed services from dynatrace")
 			return
 		}
 
@@ -222,27 +226,31 @@ func (s *serviceSynchronizer) synchronizeServices() {
 }
 
 func (s *serviceSynchronizer) synchronizeEntity(entity entity) {
-	s.logger.Debug(fmt.Sprintf("Synchronizing entity: %s", entity.EntityID))
+	log.WithField("entityId", entity.EntityID).Debug("Synchronizing entity")
 
 	serviceName, err := getKeptnServiceName(entity)
 	if err != nil {
-		s.logger.Debug(fmt.Sprintf("Skipping entity %s due to no valid service name", entity.EntityID))
+		log.WithField("entityId", entity.EntityID).Debug("Skipping entity due to no valid service name")
 		return
 	}
-	s.logger.Debug(fmt.Sprintf("Got %s as service name for entity %s", serviceName, entity.EntityID))
+	log.WithFields(
+		log.Fields{
+			"serviceName": serviceName,
+			"entityId":    entity.EntityID,
+		}).Debug("Got service name for entity")
 
 	if doesServiceExist(s.servicesInKeptn, serviceName) {
-		s.logger.Debug(fmt.Sprintf("Service %s already exists in project, skipping", serviceName))
+		log.WithField("service", serviceName).Debug("Service already exists in project, skipping")
 		return
 	}
 
 	if err := s.addServiceToKeptn(serviceName); err != nil {
-		s.logger.Error(fmt.Sprintf("Could not synchronize DT entity with ID %s: %s", entity.EntityID, err.Error()))
+		log.WithError(err).WithField("entityId", entity.EntityID).Error("Could not synchronize DT entity")
 	}
 }
 
 func (s *serviceSynchronizer) establishDTAPIConnection() error {
-	dynatraceConfig, err := s.dtConfigGetter.GetDynatraceConfig(initSyncEventAdapter{}, s.logger)
+	dynatraceConfig, err := s.dtConfigGetter.GetDynatraceConfig(initSyncEventAdapter{})
 	if err != nil {
 		return fmt.Errorf("failed to load Dynatrace config: %s", err.Error())
 	}
@@ -331,18 +339,18 @@ func (s *serviceSynchronizer) addServiceToKeptn(serviceName string) error {
 		return fmt.Errorf("could not create service %s: %s", serviceName, err)
 	}
 
-	s.logger.Debug(fmt.Sprintf("Service %s is available. Proceeding with uploading SLO", serviceName))
+	log.WithField("service", serviceName).Debug("Service is available. Proceeding with SLO upload.")
 
 	if err := s.createSLOResource(serviceName); err == nil {
-		s.logger.Info(fmt.Sprintf("Uploaded slo.yaml for service %s", serviceName))
+		log.WithField("service", serviceName).Info(fmt.Sprintf("Uploaded slo.yaml for service %s", serviceName))
 	} else {
-		s.logger.Info(fmt.Sprintf("Could not create SLO resource for %s: %s", serviceName, err))
+		log.WithField("service", serviceName).Info("Could not create SLO resource for service")
 	}
 
 	if err := s.createSLIResource(serviceName); err == nil {
-		s.logger.Info(fmt.Sprintf("Uploaded sli.yaml for service %s", serviceName))
+		log.WithField("service", serviceName).Info("Uploaded sli.yaml for service")
 	} else {
-		s.logger.Info(fmt.Sprintf("Could not create SLI resource for %s: %s", serviceName, err))
+		log.WithField("service", serviceName).Info("Could not create SLI resource for service")
 	}
 
 	s.servicesInKeptn = append(s.servicesInKeptn, serviceName)

--- a/pkg/lib/service_sync_test.go
+++ b/pkg/lib/service_sync_test.go
@@ -62,7 +62,6 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 	defer dtMockServer.Close()
 
 	type fields struct {
-		logger          keptncommon.LoggerInterface
 		projectsAPI     *keptnapi.ProjectHandler
 		servicesAPI     *keptnapi.ServiceHandler
 		resourcesAPI    *keptnapi.ResourceHandler
@@ -87,7 +86,6 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 		{
 			name: "",
 			fields: fields{
-				logger:       keptncommon.NewLogger("", "", ""),
 				projectsAPI:  nil,
 				servicesAPI:  nil,
 				resourcesAPI: nil,
@@ -95,7 +93,7 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 				DTHelper: NewDynatraceHelper(nil, &credentials.DTCredentials{
 					Tenant:   dtMockServer.URL,
 					ApiToken: "",
-				}, keptncommon.NewLogger("", "", "")),
+				}),
 				syncTimer:       nil,
 				keptnHandler:    nil,
 				servicesInKeptn: nil,
@@ -160,7 +158,6 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &serviceSynchronizer{
-				logger:          tt.fields.logger,
 				projectsAPI:     tt.fields.projectsAPI,
 				servicesAPI:     tt.fields.servicesAPI,
 				resourcesAPI:    tt.fields.resourcesAPI,
@@ -519,14 +516,13 @@ func Test_serviceSynchronizer_synchronizeServices(t *testing.T) {
 
 	k := getTestKeptnHandler(mockCS, mockEventBroker)
 	s := &serviceSynchronizer{
-		logger:       keptncommon.NewLogger("", "", ""),
 		projectsAPI:  keptnapi.NewProjectHandler(projectsMockAPI.URL),
 		servicesAPI:  keptnapi.NewServiceHandler(servicesMockAPI.URL),
 		resourcesAPI: keptnapi.NewResourceHandler(mockCS.URL),
 		DTHelper: NewDynatraceHelper(nil, &credentials.DTCredentials{
 			Tenant:   dtMockServer.URL,
 			ApiToken: "",
-		}, keptncommon.NewLogger("", "", "")),
+		}),
 		syncTimer:       nil,
 		keptnHandler:    k,
 		servicesInKeptn: []string{},
@@ -542,7 +538,7 @@ func Test_serviceSynchronizer_synchronizeServices(t *testing.T) {
 			},
 		},
 		dtConfigGetter: &adapter_mock.DynatraceConfigGetterInterfaceMock{
-			GetDynatraceConfigFunc: func(event adapter.EventContentAdapter, logger keptncommon.LoggerInterface) (*config.DynatraceConfigFile, error) {
+			GetDynatraceConfigFunc: func(event adapter.EventContentAdapter) (*config.DynatraceConfigFile, error) {
 				return &config.DynatraceConfigFile{}, nil
 			}},
 	}
@@ -701,7 +697,6 @@ func Test_serviceSynchronizer_addServiceToKeptn(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &serviceSynchronizer{
-				logger:            tt.fields.logger,
 				projectsAPI:       tt.fields.projectsAPI,
 				servicesAPI:       tt.fields.servicesAPI,
 				resourcesAPI:      tt.fields.resourcesAPI,


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

This PR
- Switches logging to the logrus (https://github.com/sirupsen/logrus) library
- Uses a global logger rather than passing loggers around
- Introduces structured log entries

It does not intend to change what is logged