### PR TITLE
Update service sync interval default values to 60s in code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ keptn add-resource --project=yourproject --stage=production --resource=dynatrace
 
 ### Synchronizing Service Entities detected by Dynatrace
 
-The Dynatrace service allows to automatically import Service Entities detected by Dynatrace into Keptn. To enable this feature, the environment variable `SYNCHRONIZE_DYNATRACE_SERVICES`
-needs to be set to `true`. By default, the service will scan Dynatrace for Service Entities every 300s. This interval can be configured by setting the environment variable `SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS` to the desired value.
+The Dynatrace service allows Service Entities detected by Dynatrace to be automatically imported into Keptn. To enable this feature, the environment variable `SYNCHRONIZE_DYNATRACE_SERVICES`
+needs to be set to `true`. Once enabled, the service will by default scan Dynatrace for Service Entities every 60 seconds. This interval can be configured by changing the environment variable `SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS`.
 
 To import a Service Entity into Keptn, a project with the name `dynatrace`, containing the stage `quality-gate` has to be available within Keptn. To create the project, create a `shipyard.yaml` file with the following content:
 

--- a/pkg/lib/configuration.go
+++ b/pkg/lib/configuration.go
@@ -42,10 +42,10 @@ func IsServiceSyncEnabled() bool {
 	return readEnvAsBool("SYNCHRONIZE_DYNATRACE_SERVICES", false)
 }
 
-// GetServiceSyncInterval returns the number of seconds the service synchronizer should sleep between synchronization runs
-// if the environment variable is empty or cannot be parsed, a default sync interval is used
+// GetServiceSyncInterval returns the number of seconds the service synchronizer should sleep between synchronization runs.
+// If the environment variable is empty or cannot be parsed, a default sync interval is used.
 func GetServiceSyncInterval() int {
-	return readEnvAsInt("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS", 300)
+	return readEnvAsInt("SYNCHRONIZE_DYNATRACE_SERVICES_INTERVAL_SECONDS", 60)
 }
 
 func readEnvAsBool(env string, defaultValue bool) bool {


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

This patch PR updates the default service synchronization interval to 60 seconds in the go code and service README. It is a continuation of #312 and addresses #311.