### PR TITLE
#346 removed references to KeptnLogger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/keptn/go-utils v0.8.4-0.20210512062520-b524ddf69d98
 	github.com/matryer/moq v0.2.1 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.17.0

--- a/pkg/event_handler/configure_monitoring.go
+++ b/pkg/event_handler/configure_monitoring.go
@@ -46,7 +46,7 @@ func (eh ConfigureMonitoringEventHandler) HandleEvent() error {
 	}
 	err := eh.configureMonitoring()
 	if err != nil {
-		log.Error(err.Error())
+		log.WithError(err).Error("Configure monitoring failed")
 	}
 	return nil
 }

--- a/pkg/event_handler/configure_monitoring.go
+++ b/pkg/event_handler/configure_monitoring.go
@@ -18,7 +18,6 @@ import (
 )
 
 type ConfigureMonitoringEventHandler struct {
-	Logger           keptncommon.LoggerInterface
 	Event            cloudevents.Event
 	IsCombinedLogger bool
 	WebSocket        *websocket.Conn
@@ -47,13 +46,13 @@ func (eh ConfigureMonitoringEventHandler) HandleEvent() error {
 	}
 	err := eh.configureMonitoring()
 	if err != nil {
-		eh.Logger.Error(err.Error())
+		log.Error(err.Error())
 	}
 	return nil
 }
 
 func (eh *ConfigureMonitoringEventHandler) configureMonitoring() error {
-	eh.Logger.Info("Configuring Dynatrace monitoring")
+	log.Info("Configuring Dynatrace monitoring")
 	e := &keptn.ConfigureMonitoringEventData{}
 	err := eh.Event.DataAs(e)
 	if err != nil {


### PR DESCRIPTION
This PR removes the remaining references to the previously used `KeptnLogger` in the `ConfigureMonitoringHandler` to avoid nil pointer exceptions.
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>