### PR TITLE
Create problem package

### DIFF
--- a/internal/event/helper.go
+++ b/internal/event/helper.go
@@ -1,4 +1,4 @@
-package event_handler
+package event
 
 import (
 	"net/url"
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type dtConfigurationEvent struct {
+type DtConfigurationEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -21,7 +21,7 @@ type dtConfigurationEvent struct {
 	Original         string            `json:"original,omitempty"`
 }
 
-type dtDeploymentEvent struct {
+type DtDeploymentEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -34,7 +34,7 @@ type dtDeploymentEvent struct {
 	RemediationAction string            `json:"remediationAction,omitempty"`
 }
 
-type dtInfoEvent struct {
+type DtInfoEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -44,7 +44,7 @@ type dtInfoEvent struct {
 	Title            string            `json:"title"`
 }
 
-type dtAnnotationEvent struct {
+type DtAnnotationEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -123,11 +123,11 @@ func createCustomProperties(a adapter.EventContentAdapter) map[string]string {
 	return customProperties
 }
 
-// createInfoEvent creates a new Info event
-func createInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtInfoEvent {
+// CreateInfoEvent creates a new Info event
+func CreateInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtInfoEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
-	var ie dtInfoEvent
+	var ie DtInfoEvent
 	ie.EventType = "CUSTOM_INFO"
 	ie.Source = "Keptn dynatrace-service"
 	ie.Title = a.GetLabels()["title"]
@@ -144,11 +144,11 @@ func createInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.Dyna
 	return ie
 }
 
-// createAnnotationEvent creates a Dynatrace ANNOTATION event
-func createAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtAnnotationEvent {
+// CreateAnnotationEvent creates a Dynatrace ANNOTATION event
+func CreateAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtAnnotationEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
-	var ie dtAnnotationEvent
+	var ie DtAnnotationEvent
 	ie.EventType = "CUSTOM_ANNOTATION"
 	ie.Source = "Keptn dynatrace-service"
 	ie.AnnotationType = a.GetLabels()["type"]
@@ -173,10 +173,10 @@ func getValueFromLabels(a adapter.EventContentAdapter, key string, defaultValue 
 	return defaultValue
 }
 
-func createDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtDeploymentEvent {
+func CreateDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtDeploymentEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
-	var de dtDeploymentEvent
+	var de DtDeploymentEvent
 	de.EventType = "CUSTOM_DEPLOYMENT"
 	de.Source = "Keptn dynatrace-service"
 	de.DeploymentName = getValueFromLabels(a, "deploymentName", "Deploy "+a.GetService()+" "+a.GetTag()+" with strategy "+a.GetDeploymentStrategy())
@@ -197,10 +197,10 @@ func createDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *confi
 	return de
 }
 
-func createConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) dtConfigurationEvent {
+func CreateConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtConfigurationEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
-	var de dtConfigurationEvent
+	var de DtConfigurationEvent
 	de.EventType = "CUSTOM_CONFIGURATION"
 	de.Source = "Keptn dynatrace-service"
 
@@ -216,7 +216,8 @@ func createConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *co
 	return de
 }
 
-func getShKeptnContext(event cloudevents.Event) string {
+// GetShKeptnContext extracts the keptn context from a CloudEvent
+func GetShKeptnContext(event cloudevents.Event) string {
 	shkeptncontext, err := types.ToString(event.Context.GetExtensions()["shkeptncontext"])
 	if err != nil {
 		log.WithError(err).Debug("Event does not contain shkeptncontext")
@@ -224,7 +225,8 @@ func getShKeptnContext(event cloudevents.Event) string {
 	return shkeptncontext
 }
 
-func getEventSource() string {
+// GetEventSource gets the source to be used for CloudEvents originating from the dynatrace-service
+func GetEventSource() string {
 	source, _ := url.Parse("dynatrace-service")
 	return source.String()
 }

--- a/internal/event/helper.go
+++ b/internal/event/helper.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type DtConfigurationEvent struct {
+type DTConfigurationEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -21,7 +21,7 @@ type DtConfigurationEvent struct {
 	Original         string            `json:"original,omitempty"`
 }
 
-type DtDeploymentEvent struct {
+type DTDeploymentEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -34,7 +34,7 @@ type DtDeploymentEvent struct {
 	RemediationAction string            `json:"remediationAction,omitempty"`
 }
 
-type DtInfoEvent struct {
+type DTInfoEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -44,7 +44,7 @@ type DtInfoEvent struct {
 	Title            string            `json:"title"`
 }
 
-type DtAnnotationEvent struct {
+type DTAnnotationEvent struct {
 	EventType   string               `json:"eventType"`
 	Source      string               `json:"source"`
 	AttachRules config.DtAttachRules `json:"attachRules"`
@@ -124,10 +124,10 @@ func createCustomProperties(a adapter.EventContentAdapter) map[string]string {
 }
 
 // CreateInfoEvent creates a new Info event
-func CreateInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtInfoEvent {
+func CreateInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DTInfoEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
-	var ie DtInfoEvent
+	var ie DTInfoEvent
 	ie.EventType = "CUSTOM_INFO"
 	ie.Source = "Keptn dynatrace-service"
 	ie.Title = a.GetLabels()["title"]
@@ -145,10 +145,10 @@ func CreateInfoEvent(a adapter.EventContentAdapter, dynatraceConfig *config.Dyna
 }
 
 // CreateAnnotationEvent creates a Dynatrace ANNOTATION event
-func CreateAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtAnnotationEvent {
+func CreateAnnotationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DTAnnotationEvent {
 
 	// we fill the Dynatrace Info Event with values from the labels or use our defaults
-	var ie DtAnnotationEvent
+	var ie DTAnnotationEvent
 	ie.EventType = "CUSTOM_ANNOTATION"
 	ie.Source = "Keptn dynatrace-service"
 	ie.AnnotationType = a.GetLabels()["type"]
@@ -173,10 +173,10 @@ func getValueFromLabels(a adapter.EventContentAdapter, key string, defaultValue 
 	return defaultValue
 }
 
-func CreateDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtDeploymentEvent {
+func CreateDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DTDeploymentEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
-	var de DtDeploymentEvent
+	var de DTDeploymentEvent
 	de.EventType = "CUSTOM_DEPLOYMENT"
 	de.Source = "Keptn dynatrace-service"
 	de.DeploymentName = getValueFromLabels(a, "deploymentName", "Deploy "+a.GetService()+" "+a.GetTag()+" with strategy "+a.GetDeploymentStrategy())
@@ -197,10 +197,10 @@ func CreateDeploymentEvent(a adapter.EventContentAdapter, dynatraceConfig *confi
 	return de
 }
 
-func CreateConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DtConfigurationEvent {
+func CreateConfigurationEvent(a adapter.EventContentAdapter, dynatraceConfig *config.DynatraceConfigFile) DTConfigurationEvent {
 
 	// we fill the Dynatrace Deployment Event with values from the labels or use our defaults
-	var de DtConfigurationEvent
+	var de DTConfigurationEvent
 	de.EventType = "CUSTOM_CONFIGURATION"
 	de.Source = "Keptn dynatrace-service"
 

--- a/internal/event_handler/cd_handler.go
+++ b/internal/event_handler/cd_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/event"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/lib"
@@ -22,7 +23,7 @@ type CDEventHandler struct {
 }
 
 func (eh CDEventHandler) HandleEvent() error {
-	shkeptncontext := getShKeptnContext(eh.Event)
+	shkeptncontext := event.GetShKeptnContext(eh.Event)
 
 	keptnHandler, err := keptnv2.NewKeptn(&eh.Event, keptncommon.KeptnOpts{})
 	if err != nil {
@@ -52,7 +53,7 @@ func (eh CDEventHandler) HandleEvent() error {
 		dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
 		// send Deployment Event
-		de := createDeploymentEvent(keptnEvent, dynatraceConfig)
+		de := event.CreateDeploymentEvent(keptnEvent, dynatraceConfig)
 		dtHelper.SendEvent(de)
 	} else if eh.Event.Type() == keptnv2.GetTriggeredEventType(keptnv2.TestTaskName) {
 		ttData := &keptnv2.TestTriggeredEventData{}
@@ -78,7 +79,7 @@ func (eh CDEventHandler) HandleEvent() error {
 		dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
 		// Send Annotation Event
-		ie := createAnnotationEvent(keptnEvent, dynatraceConfig)
+		ie := event.CreateAnnotationEvent(keptnEvent, dynatraceConfig)
 		if ie.AnnotationType == "" {
 			ie.AnnotationType = "Start Tests: " + ttData.Test.TestStrategy
 		}
@@ -110,7 +111,7 @@ func (eh CDEventHandler) HandleEvent() error {
 		dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
 		// Send Annotation Event
-		ie := createAnnotationEvent(keptnEvent, dynatraceConfig)
+		ie := event.CreateAnnotationEvent(keptnEvent, dynatraceConfig)
 
 		if ie.AnnotationType == "" {
 			ie.AnnotationType = "Stop Tests"
@@ -142,7 +143,7 @@ func (eh CDEventHandler) HandleEvent() error {
 		dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
 		// Send Info Event
-		ie := createInfoEvent(keptnEvent, dynatraceConfig)
+		ie := event.CreateInfoEvent(keptnEvent, dynatraceConfig)
 		qualityGateDescription := fmt.Sprintf("Quality Gate Result in stage %s: %s (%.2f/100)", edData.Stage, edData.Result, edData.Evaluation.Score)
 		ie.Title = fmt.Sprintf("Evaluation result: %s", edData.Result)
 
@@ -190,7 +191,7 @@ func (eh CDEventHandler) HandleEvent() error {
 		}
 		dtHelper := lib.NewDynatraceHelper(keptnHandler, creds)
 
-		ie := createInfoEvent(keptnEvent, dynatraceConfig)
+		ie := event.CreateInfoEvent(keptnEvent, dynatraceConfig)
 		if strategy == keptnevents.Direct && rtData.Result == keptnv2.ResultPass || rtData.Result == keptnv2.ResultWarning {
 			title := fmt.Sprintf("PROMOTING from %s to next stage", rtData.Stage)
 			ie.Title = title

--- a/internal/event_handler/configure_monitoring.go
+++ b/internal/event_handler/configure_monitoring.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/event"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/gorilla/websocket"
@@ -207,15 +208,15 @@ func (eh *ConfigureMonitoringEventHandler) sendConfigureMonitoringFinishedEvent(
 		},
 	}
 
-	event := cloudevents.NewEvent()
-	event.SetSource("dynatrace-service")
-	event.SetDataContentType(cloudevents.ApplicationJSON)
-	event.SetType(keptnv2.GetFinishedEventType(keptnv2.ConfigureMonitoringTaskName))
-	event.SetData(cloudevents.ApplicationJSON, cmFinishedEvent)
-	event.SetExtension("shkeptncontext", getShKeptnContext(eh.Event))
-	event.SetExtension("triggeredid", eh.Event.Context.GetID())
+	ev := cloudevents.NewEvent()
+	ev.SetSource("dynatrace-service")
+	ev.SetDataContentType(cloudevents.ApplicationJSON)
+	ev.SetType(keptnv2.GetFinishedEventType(keptnv2.ConfigureMonitoringTaskName))
+	ev.SetData(cloudevents.ApplicationJSON, cmFinishedEvent)
+	ev.SetExtension("shkeptncontext", event.GetShKeptnContext(eh.Event))
+	ev.SetExtension("triggeredid", eh.Event.Context.GetID())
 
-	if err := eh.KeptnHandler.SendCloudEvent(event); err != nil {
+	if err := eh.KeptnHandler.SendCloudEvent(ev); err != nil {
 		return fmt.Errorf("could not send %s event: %s", keptnv2.GetFinishedEventType(keptnv2.ConfigureMonitoringTaskName), err.Error())
 	}
 

--- a/internal/event_handler/get_sli_handler.go
+++ b/internal/event_handler/get_sli_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
+	"github.com/keptn-contrib/dynatrace-service/internal/event"
 	"github.com/keptn-contrib/dynatrace-service/internal/lib/dynatrace"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -511,15 +512,15 @@ func sendGetSLIFinishedEvent(inputEvent cloudevents.Event, eventData *keptnv2.Ge
 		},
 	}
 
-	event := cloudevents.NewEvent()
-	event.SetType(keptnv2.GetFinishedEventType(keptnv2.GetSLITaskName))
-	event.SetSource(getEventSource())
-	event.SetDataContentType(cloudevents.ApplicationJSON)
-	event.SetExtension("shkeptncontext", getShKeptnContext(inputEvent))
-	event.SetExtension("triggeredid", inputEvent.ID())
-	event.SetData(cloudevents.ApplicationJSON, getSLIEvent)
+	ev := cloudevents.NewEvent()
+	ev.SetType(keptnv2.GetFinishedEventType(keptnv2.GetSLITaskName))
+	ev.SetSource(event.GetEventSource())
+	ev.SetDataContentType(cloudevents.ApplicationJSON)
+	ev.SetExtension("shkeptncontext", event.GetShKeptnContext(inputEvent))
+	ev.SetExtension("triggeredid", inputEvent.ID())
+	ev.SetData(cloudevents.ApplicationJSON, getSLIEvent)
 
-	return sendEvent(event)
+	return sendEvent(ev)
 }
 
 func sendGetSLIStartedEvent(inputEvent cloudevents.Event, eventData *keptnv2.GetSLITriggeredEventData) error {
@@ -541,15 +542,15 @@ func sendGetSLIStartedEvent(inputEvent cloudevents.Event, eventData *keptnv2.Get
 		return fmt.Errorf("could not determine keptnContext of input event: %s", err.Error())
 	}
 
-	event := cloudevents.NewEvent()
-	event.SetType(keptnv2.GetStartedEventType(keptnv2.GetSLITaskName))
-	event.SetSource(getEventSource())
-	event.SetDataContentType(cloudevents.ApplicationJSON)
-	event.SetExtension("shkeptncontext", keptnContext)
-	event.SetExtension("triggeredid", inputEvent.ID())
-	event.SetData(cloudevents.ApplicationJSON, getSLIStartedEvent)
+	ev := cloudevents.NewEvent()
+	ev.SetType(keptnv2.GetStartedEventType(keptnv2.GetSLITaskName))
+	ev.SetSource(event.GetEventSource())
+	ev.SetDataContentType(cloudevents.ApplicationJSON)
+	ev.SetExtension("shkeptncontext", keptnContext)
+	ev.SetExtension("triggeredid", inputEvent.ID())
+	ev.SetData(cloudevents.ApplicationJSON, getSLIStartedEvent)
 
-	return sendEvent(event)
+	return sendEvent(ev)
 }
 
 /**

--- a/internal/event_handler/handler.go
+++ b/internal/event_handler/handler.go
@@ -24,11 +24,11 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 	case keptnevents.ProblemEventType:
 		return &problem.ProblemEventHandler{Event: event}, nil
 	case keptnv2.GetTriggeredEventType(keptnv2.ActionTaskName):
-		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DTConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetStartedEventType(keptnv2.ActionTaskName):
-		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DTConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetFinishedEventType(keptnv2.ActionTaskName):
-		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DTConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetTriggeredEventType(keptnv2.GetSLITaskName):
 		return &GetSLIEventHandler{event: event, dtConfigGetter: dtConfigGetter}, nil
 	default:

--- a/internal/event_handler/handler.go
+++ b/internal/event_handler/handler.go
@@ -3,6 +3,7 @@ package event_handler
 import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	"github.com/keptn-contrib/dynatrace-service/internal/problem"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	log "github.com/sirupsen/logrus"
@@ -21,13 +22,13 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 	case keptnv2.GetFinishedEventType(keptnv2.ProjectCreateTaskName):
 		return &CreateProjectEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnevents.ProblemEventType:
-		return &ProblemEventHandler{Event: event}, nil
+		return &problem.ProblemEventHandler{Event: event}, nil
 	case keptnv2.GetTriggeredEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetStartedEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetFinishedEventType(keptnv2.ActionTaskName):
-		return &ActionHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &problem.ActionHandler{Event: event, DtConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetTriggeredEventType(keptnv2.GetSLITaskName):
 		return &GetSLIEventHandler{event: event, dtConfigGetter: dtConfigGetter}, nil
 	default:

--- a/internal/problem/action.go
+++ b/internal/problem/action.go
@@ -1,4 +1,4 @@
-package event_handler
+package problem
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/config"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/event"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	log "github.com/sirupsen/logrus"
@@ -19,14 +20,14 @@ import (
 
 type ActionHandler struct {
 	Event          cloudevents.Event
-	dtConfigGetter adapter.DynatraceConfigGetterInterface
+	DtConfigGetter adapter.DynatraceConfigGetterInterface
 }
 
 /**
  * Retrieves Dynatrace Credential information
  */
 func (eh ActionHandler) GetDynatraceCredentials(keptnEvent adapter.EventContentAdapter) (*config.DynatraceConfigFile, *credentials.DTCredentials, error) {
-	dynatraceConfig, err := eh.dtConfigGetter.GetDynatraceConfig(keptnEvent)
+	dynatraceConfig, err := eh.DtConfigGetter.GetDynatraceConfig(keptnEvent)
 	if err != nil {
 		log.WithError(err).Error("Failed to load Dynatrace config")
 		return nil, nil, err
@@ -77,7 +78,7 @@ func (eh ActionHandler) HandleEvent() error {
 			comment = comment + ": " + actionTriggeredData.Action.Description
 		}
 
-		dynatraceConfig, err := eh.dtConfigGetter.GetDynatraceConfig(keptnEvent)
+		dynatraceConfig, err := eh.DtConfigGetter.GetDynatraceConfig(keptnEvent)
 		if err != nil {
 			log.WithError(err).Error("Failed to load Dynatrace config")
 			return err
@@ -92,7 +93,7 @@ func (eh ActionHandler) HandleEvent() error {
 
 		// https://github.com/keptn-contrib/dynatrace-service/issues/174
 		// Additionall to the problem comment, send Info and Configuration Change Event to the entities in Dynatrace to indicate that remediation actions have been executed
-		dtInfoEvent := createInfoEvent(keptnEvent, dynatraceConfig)
+		dtInfoEvent := event.CreateInfoEvent(keptnEvent, dynatraceConfig)
 		dtInfoEvent.Title = "Keptn Remediation Action Triggered"
 		dtInfoEvent.Description = actionTriggeredData.Action.Action
 		dtHelper.SendEvent(dtInfoEvent)
@@ -172,12 +173,12 @@ func (eh ActionHandler) HandleEvent() error {
 		// https://github.com/keptn-contrib/dynatrace-service/issues/174
 		// Additionally to the problem comment, send Info and Configuration Change Event to the entities in Dynatrace to indicate that remediation actions have been executed
 		if actionFinishedData.Status == keptnv2.StatusSucceeded {
-			dtConfigEvent := createConfigurationEvent(keptnEvent, dynatraceConfig)
+			dtConfigEvent := event.CreateConfigurationEvent(keptnEvent, dynatraceConfig)
 			dtConfigEvent.Description = "Keptn Remediation Action Finished"
 			dtConfigEvent.Configuration = "successful"
 			dtHelper.SendEvent(dtConfigEvent)
 		} else {
-			dtInfoEvent := createInfoEvent(keptnEvent, dynatraceConfig)
+			dtInfoEvent := event.CreateInfoEvent(keptnEvent, dynatraceConfig)
 			dtInfoEvent.Title = "Keptn Remediation Action Finished"
 			dtInfoEvent.Description = "error during execution"
 			dtHelper.SendEvent(dtInfoEvent)

--- a/internal/problem/action.go
+++ b/internal/problem/action.go
@@ -20,14 +20,14 @@ import (
 
 type ActionHandler struct {
 	Event          cloudevents.Event
-	DtConfigGetter adapter.DynatraceConfigGetterInterface
+	DTConfigGetter adapter.DynatraceConfigGetterInterface
 }
 
 /**
  * Retrieves Dynatrace Credential information
  */
 func (eh ActionHandler) GetDynatraceCredentials(keptnEvent adapter.EventContentAdapter) (*config.DynatraceConfigFile, *credentials.DTCredentials, error) {
-	dynatraceConfig, err := eh.DtConfigGetter.GetDynatraceConfig(keptnEvent)
+	dynatraceConfig, err := eh.DTConfigGetter.GetDynatraceConfig(keptnEvent)
 	if err != nil {
 		log.WithError(err).Error("Failed to load Dynatrace config")
 		return nil, nil, err
@@ -78,7 +78,7 @@ func (eh ActionHandler) HandleEvent() error {
 			comment = comment + ": " + actionTriggeredData.Action.Description
 		}
 
-		dynatraceConfig, err := eh.DtConfigGetter.GetDynatraceConfig(keptnEvent)
+		dynatraceConfig, err := eh.DTConfigGetter.GetDynatraceConfig(keptnEvent)
 		if err != nil {
 			log.WithError(err).Error("Failed to load Dynatrace config")
 			return err

--- a/internal/problem/problem_handler.go
+++ b/internal/problem/problem_handler.go
@@ -1,4 +1,4 @@
-package event_handler
+package problem
 
 import (
 	"encoding/json"
@@ -10,6 +10,7 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
+	"github.com/keptn-contrib/dynatrace-service/internal/event"
 	keptn "github.com/keptn/go-utils/pkg/lib"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -89,7 +90,7 @@ func (eh ProblemEventHandler) HandleEvent() error {
 		return nil
 	}
 
-	shkeptncontext := getShKeptnContext(eh.Event)
+	shkeptncontext := event.GetShKeptnContext(eh.Event)
 
 	dtProblemEvent := &DTProblemEvent{}
 	err := eh.Event.DataAs(dtProblemEvent)
@@ -220,7 +221,7 @@ func createAndSendCE(problemData interface{}, shkeptncontext string, eventType s
 
 	ce := cloudevents.NewEvent()
 	ce.SetType(eventType)
-	ce.SetSource(getEventSource())
+	ce.SetSource(event.GetEventSource())
 	ce.SetDataContentType(cloudevents.ApplicationJSON)
 	ce.SetData(cloudevents.ApplicationJSON, problemData)
 	ce.SetExtension("shkeptncontext", shkeptncontext)


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

This PR moves `problem.go` and `action.go` to `problem` package.
Along the way, `helper.go` had to be moved to its own package `event`, with some functions and structs being exported.