### PR TITLE
moves configure_monitoring.go to own package 'monitoring'

### DIFF
--- a/internal/event_handler/handler.go
+++ b/internal/event_handler/handler.go
@@ -3,6 +3,7 @@ package event_handler
 import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	"github.com/keptn-contrib/dynatrace-service/internal/monitoring"
 	"github.com/keptn-contrib/dynatrace-service/internal/problem"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -18,7 +19,7 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 	dtConfigGetter := &adapter.DynatraceConfigGetter{}
 	switch event.Type() {
 	case keptnevents.ConfigureMonitoringEventType:
-		return &ConfigureMonitoringEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
+		return &monitoring.ConfigureMonitoringEventHandler{Event: event, DTConfigGetter: dtConfigGetter}, nil
 	case keptnv2.GetFinishedEventType(keptnv2.ProjectCreateTaskName):
 		return &CreateProjectEventHandler{Event: event, dtConfigGetter: dtConfigGetter}, nil
 	case keptnevents.ProblemEventType:

--- a/internal/monitoring/configure_monitoring.go
+++ b/internal/monitoring/configure_monitoring.go
@@ -1,4 +1,4 @@
-package event_handler
+package monitoring
 
 import (
 	"errors"
@@ -23,7 +23,7 @@ type ConfigureMonitoringEventHandler struct {
 	IsCombinedLogger bool
 	WebSocket        *websocket.Conn
 	KeptnHandler     *keptnv2.Keptn
-	dtConfigGetter   adapter.DynatraceConfigGetterInterface
+	DTConfigGetter   adapter.DynatraceConfigGetterInterface
 }
 
 type KeptnAPIConnectionCheck struct {
@@ -99,7 +99,7 @@ func (eh *ConfigureMonitoringEventHandler) configureMonitoring() error {
 
 	keptnEvent := adapter.NewConfigureMonitoringAdapter(*e, keptnHandler.KeptnContext, eh.Event.Source())
 
-	dynatraceConfig, err := eh.dtConfigGetter.GetDynatraceConfig(keptnEvent)
+	dynatraceConfig, err := eh.DTConfigGetter.GetDynatraceConfig(keptnEvent)
 	if err != nil {
 		msg := fmt.Sprintf("failed to load Dynatrace config: %v", err)
 		return eh.handleError(e, msg)


### PR DESCRIPTION
Signed-off-by: Joerg Poecher <j-poecher@users.noreply.github.com>

