### PR TITLE
Create onboard package

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"os"
 
-	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
-	"github.com/keptn-contrib/dynatrace-service/internal/lib"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
+	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
 	"github.com/keptn-contrib/dynatrace-service/internal/event_handler"
+	"github.com/keptn-contrib/dynatrace-service/internal/lib"
+	"github.com/keptn-contrib/dynatrace-service/internal/onboard"
+
+	log "github.com/sirupsen/logrus"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -45,7 +46,7 @@ func _main(args []string, env envConfig) int {
 		if err != nil {
 			log.WithError(err).Fatal("Failed to initialize CredentialManager")
 		}
-		lib.ActivateServiceSynchronizer(cm)
+		onboard.ActivateServiceSynchronizer(cm)
 	}
 
 	ctx := context.Background()

--- a/internal/event_handler/cd_handler.go
+++ b/internal/event_handler/cd_handler.go
@@ -12,9 +12,9 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
 	"github.com/keptn-contrib/dynatrace-service/internal/event"
+	"github.com/keptn-contrib/dynatrace-service/internal/lib"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/keptn-contrib/dynatrace-service/internal/lib"
 )
 
 type CDEventHandler struct {

--- a/internal/lib/auto_tags.go
+++ b/internal/lib/auto_tags.go
@@ -14,7 +14,7 @@ func (dt *DynatraceHelper) EnsureDTTaggingRulesAreSetUp() {
 
 	log.Info("Setting up auto-tagging rules in Dynatrace Tenant")
 
-	response, err := dt.sendDynatraceAPIRequest("/api/config/v1/autoTags", "GET", nil)
+	response, err := dt.SendDynatraceAPIRequest("/api/config/v1/autoTags", "GET", nil)
 	if err != nil {
 		// Error occurred but continue
 		log.WithError(err).Error("Could not get existing tagging rules")
@@ -64,7 +64,7 @@ func (dt *DynatraceHelper) createDTTaggingRule(rule *DTTaggingRule) error {
 	if err != nil {
 		return err
 	}
-	_, err = dt.sendDynatraceAPIRequest("/api/config/v1/autoTags", "POST", payload)
+	_, err = dt.SendDynatraceAPIRequest("/api/config/v1/autoTags", "POST", payload)
 	return err
 }
 

--- a/internal/lib/dashboard.go
+++ b/internal/lib/dashboard.go
@@ -35,7 +35,7 @@ func (dt *DynatraceHelper) CreateDashboard(project string, shipyard keptnv2.Ship
 		return
 	}
 
-	_, err = dt.sendDynatraceAPIRequest("/api/config/v1/dashboards", "POST", dashboardPayload)
+	_, err = dt.SendDynatraceAPIRequest("/api/config/v1/dashboards", "POST", dashboardPayload)
 	if err != nil {
 		log.WithError(err).Error("Failed to create Dynatrace dashboards")
 		dt.configuredEntities.Dashboard.Success = false
@@ -52,7 +52,7 @@ const dashboardNameSuffix = "@keptn: Digital Delivery & Operations Dashboard"
 
 // DeleteExistingDashboard deletes an existing dashboard for the provided project
 func (dt *DynatraceHelper) DeleteExistingDashboard(project string) error {
-	res, err := dt.sendDynatraceAPIRequest("/api/config/v1/dashboards", "GET", nil)
+	res, err := dt.SendDynatraceAPIRequest("/api/config/v1/dashboards", "GET", nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve list of existing Dynatrace dashboards: %v", err)
 	}
@@ -66,7 +66,7 @@ func (dt *DynatraceHelper) DeleteExistingDashboard(project string) error {
 
 	for _, dashboardItem := range dtDashboardsResponse.Dashboards {
 		if dashboardItem.Name == project+dashboardNameSuffix {
-			res, err = dt.sendDynatraceAPIRequest("/api/config/v1/dashboards/"+dashboardItem.ID, "DELETE", nil)
+			res, err = dt.SendDynatraceAPIRequest("/api/config/v1/dashboards/"+dashboardItem.ID, "DELETE", nil)
 			if err != nil {
 				return fmt.Errorf("Could not delete dashboard for project %s: %v", project, err)
 			}

--- a/internal/lib/dynatrace.go
+++ b/internal/lib/dynatrace.go
@@ -130,10 +130,8 @@ func shouldCreateMetricEvents(stage keptnv2.Stage) bool {
 	return false
 }
 
-/**
- * if dtCredsSecretName is passed and it is not dynatrace (=default) then we try to pull the secret based on that name and is it for this API Call
- */
-func (dt *DynatraceHelper) sendDynatraceAPIRequest(apiPath string, method string, body []byte) (string, error) {
+// SendDynatraceAPIRequest makes an Dynatrace API request and returns the response
+func (dt *DynatraceHelper) SendDynatraceAPIRequest(apiPath string, method string, body []byte) (string, error) {
 
 	if common.RunLocal || common.RunLocalTest {
 		log.WithFields(

--- a/internal/lib/dynatrace_events.go
+++ b/internal/lib/dynatrace_events.go
@@ -17,7 +17,7 @@ func (dt *DynatraceHelper) SendEvent(dtEvent interface{}) {
 		return
 	}
 
-	body, err := dt.sendDynatraceAPIRequest("/api/v1/events", "POST", jsonString)
+	body, err := dt.SendDynatraceAPIRequest("/api/v1/events", "POST", jsonString)
 	if err != nil {
 		log.WithError(err).Error("Failed sending Dynatrace API request")
 	} else {

--- a/internal/lib/management_zones.go
+++ b/internal/lib/management_zones.go
@@ -26,7 +26,7 @@ func (dt *DynatraceHelper) CreateManagementZones(project string, shipyard keptnv
 		managementZone := CreateManagementZoneForProject(project)
 		mzPayload, err := json.Marshal(managementZone)
 		if err == nil {
-			_, err := dt.sendDynatraceAPIRequest("/api/config/v1/managementZones", "POST", mzPayload)
+			_, err := dt.SendDynatraceAPIRequest("/api/config/v1/managementZones", "POST", mzPayload)
 			if err != nil {
 				// Error occurred but continue
 
@@ -67,7 +67,7 @@ func (dt *DynatraceHelper) CreateManagementZones(project string, shipyard keptnv
 			managementZone := CreateManagementZoneForStage(project, stage.Name)
 			mzPayload, err := json.Marshal(managementZone)
 			if err == nil {
-				_, err = dt.sendDynatraceAPIRequest("/api/config/v1/managementZones", "POST", mzPayload)
+				_, err = dt.SendDynatraceAPIRequest("/api/config/v1/managementZones", "POST", mzPayload)
 
 				if err != nil {
 					log.WithError(err).Error("Could not create management zone")
@@ -100,7 +100,7 @@ func getManagementZoneNameForStage(project string, stage string) string {
 }
 
 func (dt *DynatraceHelper) getManagementZones() []Values {
-	response, err := dt.sendDynatraceAPIRequest("/api/config/v1/managementZones", "GET", nil)
+	response, err := dt.SendDynatraceAPIRequest("/api/config/v1/managementZones", "GET", nil)
 	if err != nil {
 		log.WithError(err).Error("Failed to retrieve management zones")
 		return nil

--- a/internal/lib/metric_events.go
+++ b/internal/lib/metric_events.go
@@ -121,7 +121,7 @@ func (dt *DynatraceHelper) CreateMetricEvents(project string, stage string, serv
 					}
 				}
 
-				_, err = dt.sendDynatraceAPIRequest(apiURL, apiMethod, mePayload)
+				_, err = dt.SendDynatraceAPIRequest(apiURL, apiMethod, mePayload)
 				if err != nil {
 					log.WithError(err).WithField("metricName", newMetricEvent.Name).Error("Could not create metric event")
 					continue
@@ -160,7 +160,7 @@ func (dt *DynatraceHelper) getCustomQueries(project string, stage string, servic
 }
 
 func (dt *DynatraceHelper) GetMetricEvent(eventKey string) (*MetricEvent, error) {
-	res, err := dt.sendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents", "GET", nil)
+	res, err := dt.SendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents", "GET", nil)
 	if err != nil {
 		log.WithError(err).Error("Could not retrieve list of existing Dynatrace metric events")
 		return nil, err
@@ -176,7 +176,7 @@ func (dt *DynatraceHelper) GetMetricEvent(eventKey string) (*MetricEvent, error)
 
 	for _, metricEvent := range dtMetricEvents.Values {
 		if metricEvent.Name == eventKey {
-			res, err = dt.sendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents/"+metricEvent.ID, "GET", nil)
+			res, err = dt.SendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents/"+metricEvent.ID, "GET", nil)
 			if err != nil {
 				log.WithError(err).WithField("eventKey", eventKey).Error("Could not get existing metric event")
 				return nil, err
@@ -193,7 +193,7 @@ func (dt *DynatraceHelper) GetMetricEvent(eventKey string) (*MetricEvent, error)
 }
 
 func (dt *DynatraceHelper) DeleteExistingMetricEvent(eventKey string) error {
-	res, err := dt.sendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents", "GET", nil)
+	res, err := dt.SendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents", "GET", nil)
 	if err != nil {
 		log.WithError(err).Error("Could not retrieve list of existing Dynatrace metric events")
 		return err
@@ -209,7 +209,7 @@ func (dt *DynatraceHelper) DeleteExistingMetricEvent(eventKey string) error {
 
 	for _, metricEvent := range dtMetricEvents.Values {
 		if metricEvent.Name == eventKey {
-			res, err = dt.sendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents/"+metricEvent.ID, "DELETE", nil)
+			res, err = dt.SendDynatraceAPIRequest("/api/config/v1/anomalyDetection/metricEvents/"+metricEvent.ID, "DELETE", nil)
 			if err != nil {
 				log.WithError(err).WithField("eventKey", eventKey).Error("Could not delete existing metric event")
 				return err

--- a/internal/lib/problem_comment.go
+++ b/internal/lib/problem_comment.go
@@ -17,7 +17,7 @@ func (dt *DynatraceHelper) SendProblemComment(problemID string, comment string) 
 
 	log.WithField("jsonPayload", jsonPayload).Info("Sending problem event")
 
-	resp, err := dt.sendDynatraceAPIRequest("/api/v1/problem/details/"+problemID+"/comments", "POST", jsonPayload)
+	resp, err := dt.SendDynatraceAPIRequest("/api/v1/problem/details/"+problemID+"/comments", "POST", jsonPayload)
 
 	log.WithField("response", resp).Info("Received response from Dynatrace API")
 	if err != nil {

--- a/internal/lib/problem_notifications.go
+++ b/internal/lib/problem_notifications.go
@@ -26,7 +26,7 @@ func (dt *DynatraceHelper) EnsureProblemNotificationsAreSetUp() {
 		return
 	}
 
-	response, err := dt.sendDynatraceAPIRequest("/api/config/v1/notifications", "GET", nil)
+	response, err := dt.SendDynatraceAPIRequest("/api/config/v1/notifications", "GET", nil)
 	existingNotifications := DTAPIListResponse{}
 
 	err = json.Unmarshal([]byte(response), &existingNotifications)
@@ -36,7 +36,7 @@ func (dt *DynatraceHelper) EnsureProblemNotificationsAreSetUp() {
 
 	for _, notification := range existingNotifications.Values {
 		if notification.Name == "Keptn Problem Notification" {
-			_, err = dt.sendDynatraceAPIRequest("/api/config/v1/notifications/"+notification.ID, "DELETE", nil)
+			_, err = dt.SendDynatraceAPIRequest("/api/config/v1/notifications/"+notification.ID, "DELETE", nil)
 			if err != nil {
 				// Error occurred but continue
 				log.WithError(err).WithField("notificationId", notification.ID).Error("Failed to delete notification")
@@ -57,7 +57,7 @@ func (dt *DynatraceHelper) EnsureProblemNotificationsAreSetUp() {
 	problemNotification = strings.ReplaceAll(problemNotification, "$KEPTN_TOKEN", keptnCredentials.APIToken)
 	problemNotification = strings.ReplaceAll(problemNotification, "$ALERTING_PROFILE_ID", alertingProfileId)
 
-	_, err = dt.sendDynatraceAPIRequest("/api/config/v1/notifications", "POST", []byte(problemNotification))
+	_, err = dt.SendDynatraceAPIRequest("/api/config/v1/notifications", "POST", []byte(problemNotification))
 	if err != nil {
 		log.WithError(err).Error("Failed to set up problem notification")
 		dt.configuredEntities.ProblemNotifications.Success = false
@@ -69,7 +69,7 @@ func (dt *DynatraceHelper) EnsureProblemNotificationsAreSetUp() {
 
 func (dt *DynatraceHelper) setupAlertingProfile() (string, error) {
 	log.Info("Checking Keptn alerting profile availability")
-	response, err := dt.sendDynatraceAPIRequest("/api/config/v1/alertingProfiles", "GET", nil)
+	response, err := dt.SendDynatraceAPIRequest("/api/config/v1/alertingProfiles", "GET", nil)
 	if err != nil {
 		// Error occurred but continue
 		log.WithError(err).Debug("Could not get alerting profiles")
@@ -96,7 +96,7 @@ func (dt *DynatraceHelper) setupAlertingProfile() (string, error) {
 		return "", fmt.Errorf("failed to marshal alerting profile: %v", err)
 	}
 
-	response, err = dt.sendDynatraceAPIRequest("/api/config/v1/alertingProfiles", "POST", alertingProfilePayload)
+	response, err = dt.SendDynatraceAPIRequest("/api/config/v1/alertingProfiles", "POST", alertingProfilePayload)
 	if err != nil {
 		return "", fmt.Errorf("failed to setup alerting profile: %v", err)
 	}

--- a/internal/onboard/service_sync.go
+++ b/internal/onboard/service_sync.go
@@ -1,4 +1,4 @@
-package lib
+package onboard
 
 import (
 	"bytes"
@@ -15,6 +15,7 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/lib"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
@@ -120,7 +121,7 @@ type serviceSynchronizer struct {
 	resourcesAPI      *keptnapi.ResourceHandler
 	apiHandler        *keptnapi.APIHandler
 	credentialManager credentials.CredentialManagerInterface
-	DTHelper          *DynatraceHelper
+	DTHelper          *lib.DynatraceHelper
 	syncTimer         *time.Ticker
 	keptnHandler      *keptnv2.Keptn
 	servicesInKeptn   []string
@@ -142,7 +143,7 @@ func ActivateServiceSynchronizer(c *credentials.CredentialManager) *serviceSynch
 		}
 
 		serviceSynchronizerInstance.dtConfigGetter = &adapter.DynatraceConfigGetter{}
-		serviceSynchronizerInstance.DTHelper = NewDynatraceHelper(nil, nil)
+		serviceSynchronizerInstance.DTHelper = lib.NewDynatraceHelper(nil, nil)
 
 		configServiceBaseURL := common.GetConfigurationServiceURL()
 		shipyardControllerBaseURL := common.GetShipyardControllerURL()
@@ -163,7 +164,7 @@ func ActivateServiceSynchronizer(c *credentials.CredentialManager) *serviceSynch
 }
 
 func (s *serviceSynchronizer) initializeSynchronizationTimer() {
-	syncInterval := GetServiceSyncInterval()
+	syncInterval := lib.GetServiceSyncInterval()
 	log.WithField("syncInterval", syncInterval).Info("Service Synchronizer will sync periodically")
 	s.syncTimer = time.NewTicker(time.Duration(syncInterval) * time.Second)
 	go func() {
@@ -281,7 +282,7 @@ func (s *serviceSynchronizer) fetchKeptnManagedServicesFromDynatrace(nextPageKey
 	} else {
 		query = "/api/v2/entities?nextPageKey=" + nextPageKey
 	}
-	response, err := s.DTHelper.sendDynatraceAPIRequest(query, http.MethodGet, nil)
+	response, err := s.DTHelper.SendDynatraceAPIRequest(query, http.MethodGet, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch service entities with 'keptn_managed' and 'keptn_service' tags: %v", err)
 	}

--- a/internal/onboard/service_sync_test.go
+++ b/internal/onboard/service_sync_test.go
@@ -1,4 +1,4 @@
-package lib
+package onboard
 
 import (
 	"encoding/json"
@@ -20,6 +20,7 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/config"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
 	credentials_mock "github.com/keptn-contrib/dynatrace-service/internal/credentials/mock"
+	"github.com/keptn-contrib/dynatrace-service/internal/lib"
 	"github.com/keptn/go-utils/pkg/api/models"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
@@ -66,7 +67,7 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 		servicesAPI     *keptnapi.ServiceHandler
 		resourcesAPI    *keptnapi.ResourceHandler
 		apiMutex        sync.Mutex
-		DTHelper        *DynatraceHelper
+		DTHelper        *lib.DynatraceHelper
 		syncTimer       *time.Ticker
 		keptnHandler    *keptnv2.Keptn
 		servicesInKeptn []string
@@ -90,7 +91,7 @@ func Test_serviceSynchronizer_fetchKeptnManagedServicesFromDynatrace(t *testing.
 				servicesAPI:  nil,
 				resourcesAPI: nil,
 				apiMutex:     sync.Mutex{},
-				DTHelper: NewDynatraceHelper(nil, &credentials.DTCredentials{
+				DTHelper: lib.NewDynatraceHelper(nil, &credentials.DTCredentials{
 					Tenant:   dtMockServer.URL,
 					ApiToken: "",
 				}),
@@ -519,7 +520,7 @@ func Test_serviceSynchronizer_synchronizeServices(t *testing.T) {
 		projectsAPI:  keptnapi.NewProjectHandler(projectsMockAPI.URL),
 		servicesAPI:  keptnapi.NewServiceHandler(servicesMockAPI.URL),
 		resourcesAPI: keptnapi.NewResourceHandler(mockCS.URL),
-		DTHelper: NewDynatraceHelper(nil, &credentials.DTCredentials{
+		DTHelper: lib.NewDynatraceHelper(nil, &credentials.DTCredentials{
 			Tenant:   dtMockServer.URL,
 			ApiToken: "",
 		}),
@@ -660,7 +661,7 @@ func Test_serviceSynchronizer_addServiceToKeptn(t *testing.T) {
 		apiHandler        *keptnapi.APIHandler
 		credentialManager credentials.CredentialManagerInterface
 		apiMutex          sync.Mutex
-		DTHelper          *DynatraceHelper
+		DTHelper          *lib.DynatraceHelper
 		syncTimer         *time.Ticker
 		keptnHandler      *keptnv2.Keptn
 		servicesInKeptn   []string


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

This PR moves `service_sync.go` and `service_sync_test.go` to the `onboard` package. References to `DTHelper` had to be updated, which had to have `SendDynatraceAPIRequest` exported.