### PR TITLE
Feature/431/environment varible for log level

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,9 +23,7 @@ type envConfig struct {
 }
 
 func main() {
-	// only emit logs of info and higher in formal builds
-	// keep trace and debug for development
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(lib.GetLogLevel())
 
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {

--- a/documentation/development.md
+++ b/documentation/development.md
@@ -10,3 +10,7 @@
 ## Debugging
 
 Remote debugging is supported using [Skaffold](https://skaffold.dev/) via `skaffold debug`, which starts a [Delve](https://github.com/go-delve/delve) instance prior to running the service.
+
+## Setting the log output level
+
+The minimum log level of messages emitted by the service may be set using the `LOG_LEVEL_DYNATRACE_SERVICE` environment variable. The following levels are supported: `panic`, `fatal`, `error`,`warn` (or `warning`), `info`, `debug` and `trace`. By default the minimum level is set to `info`, meaning that info, warning, error, fatal and panic messages are emitted.

--- a/internal/lib/configuration.go
+++ b/internal/lib/configuration.go
@@ -7,6 +7,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const logLevelEnvironmentVariable = "LOG_LEVEL_DYNATRACE_SERVICE"
+
+// GetLogLevel gets the log level specified by the LOG_LEVEL_DYNATRACE_SERVICE environment variable.
+// If none is specified, log.InfoLevel is assumed.
+func GetLogLevel() log.Level {
+	level, err := log.ParseLevel(os.Getenv(logLevelEnvironmentVariable))
+	if err != nil {
+		log.WithError(err).Error("Couldn't parse " + logLevelEnvironmentVariable + " environment variable")
+		return log.InfoLevel
+	}
+
+	return level
+}
+
 // IsTaggingRulesGenerationEnabled returns whether tagging rules should be generated when configuring the monitoring
 func IsTaggingRulesGenerationEnabled() bool {
 	return readEnvAsBool("GENERATE_TAGGING_RULES", false)


### PR DESCRIPTION
This PR adds the `LOG_LEVEL_DYNATRACE_SERVICE` environment variable for setting the minimum log level.

Closes #431 