### PR TITLE
Fix typo in apiPath in EntitiesClient

### DIFF
--- a/internal/dynatrace/entities_client.go
+++ b/internal/dynatrace/entities_client.go
@@ -55,7 +55,7 @@ func (ec *EntitiesClient) GetKeptnManagedServices() ([]Entity, error) {
 		var err error
 
 		if nextPageKey == "" {
-			response, err = ec.Client.Get(entitiesPath + "entitySelector=type(\"SERVICE\")%20AND%20tag(\"keptn_managed\",\"[Environment]keptn_managed\")%20AND%20tag(\"keptn_service\",\"[Environment]keptn_service\")&fields=+tags&pageSize=" + strconv.FormatInt(int64(pageSize), 10))
+			response, err = ec.Client.Get(entitiesPath + "?entitySelector=type(\"SERVICE\")%20AND%20tag(\"keptn_managed\",\"[Environment]keptn_managed\")%20AND%20tag(\"keptn_service\",\"[Environment]keptn_service\")&fields=+tags&pageSize=" + strconv.FormatInt(int64(pageSize), 10))
 		} else {
 			response, err = ec.Client.Get(entitiesPath + "?nextPageKey=" + nextPageKey)
 		}


### PR DESCRIPTION
This PR adds a missing `?` to the `apiPath` used in `GetKeptnManagedServices()`.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>