### PR TITLE
Pass missing eventData to ConfigureMonitoringFinishedEventFactory

### DIFF
--- a/internal/monitoring/configure_monitoring_event_handler.go
+++ b/internal/monitoring/configure_monitoring_event_handler.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"fmt"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
@@ -158,11 +159,11 @@ func getConfigureMonitoringResultMessage(apiCheck *KeptnAPIConnectionCheck, enti
 
 func (eh *ConfigureMonitoringEventHandler) handleError(err error) error {
 	log.Error(err)
-	return eh.sendConfigureMonitoringFinishedEvent(NewFailureEventFactory(err.Error()))
+	return eh.sendConfigureMonitoringFinishedEvent(NewFailureEventFactory(eh.event, err.Error()))
 }
 
 func (eh *ConfigureMonitoringEventHandler) handleSuccess(message string) error {
-	return eh.sendConfigureMonitoringFinishedEvent(NewSuccessEventFactory(message))
+	return eh.sendConfigureMonitoringFinishedEvent(NewSuccessEventFactory(eh.event, message))
 }
 
 func (eh *ConfigureMonitoringEventHandler) sendConfigureMonitoringFinishedEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/monitoring/configure_monitoring_finished_factory.go
+++ b/internal/monitoring/configure_monitoring_finished_factory.go
@@ -17,19 +17,21 @@ func (f *ConfigureMonitoringFinishedEventFactory) CreateCloudEvent() (*cloudeven
 	return f.getEventFactory(f.status, f.result, f.message).CreateCloudEvent()
 }
 
-func NewSuccessEventFactory(message string) *ConfigureMonitoringFinishedEventFactory {
+func NewSuccessEventFactory(eventData ConfigureMonitoringAdapterInterface, message string) *ConfigureMonitoringFinishedEventFactory {
 	return &ConfigureMonitoringFinishedEventFactory{
-		status:  keptnv2.StatusSucceeded,
-		result:  keptnv2.ResultPass,
-		message: message,
+		eventData: eventData,
+		status:    keptnv2.StatusSucceeded,
+		result:    keptnv2.ResultPass,
+		message:   message,
 	}
 }
 
-func NewFailureEventFactory(message string) *ConfigureMonitoringFinishedEventFactory {
+func NewFailureEventFactory(eventData ConfigureMonitoringAdapterInterface, message string) *ConfigureMonitoringFinishedEventFactory {
 	return &ConfigureMonitoringFinishedEventFactory{
-		status:  keptnv2.StatusErrored,
-		result:  keptnv2.ResultFailed,
-		message: message,
+		eventData: eventData,
+		status:    keptnv2.StatusErrored,
+		result:    keptnv2.ResultFailed,
+		message:   message,
 	}
 }
 


### PR DESCRIPTION
Looking at:
https://github.com/keptn-contrib/dynatrace-service/blob/30f9fd982bdcc2bf77bc53c114f9d8aacb4a291b/internal/monitoring/configure_monitoring_finished_factory.go#L20-L34
These methods currently don't set `eventData` of the `ConfigureMonitoringFinishedEventFactory` structs, but this is used in `getEventFactory`. This PR would rectify this.