### PR TITLE
Patch/395/use dimension key in merge

### DIFF
--- a/internal/dynatrace/metrics_client.go
+++ b/internal/dynatrace/metrics_client.go
@@ -3,6 +3,7 @@ package dynatrace
 import (
 	"encoding/json"
 	"errors"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,13 +20,15 @@ type MetricDefinition struct {
 	DefaultAggregation struct {
 		Type string `json:"type"`
 	} `json:"defaultAggregation"`
-	DimensionDefinitions []struct {
-		Name        string `json:"name"`
-		Type        string `json:"type"`
-		Key         string `json:"key"`
-		DisplayName string `json:"displayName"`
-	} `json:"dimensionDefinitions"`
-	EntityType []string `json:"entityType"`
+	DimensionDefinitions []DimensionDefinition `json:"dimensionDefinitions"`
+	EntityType           []string              `json:"entityType"`
+}
+
+type DimensionDefinition struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Key         string `json:"key"`
+	DisplayName string `json:"displayName"`
 }
 
 // MetricsQueryResult is struct for /metrics/query

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -3,6 +3,7 @@ package keptn
 import (
 	"errors"
 	"fmt"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
@@ -101,15 +102,15 @@ func getDefaultQuery(sliName string) (string, error) {
 	// Switched to new metric v2 query language as discussed here: https://github.com/keptn-contrib/dynatrace-sli-service/issues/91
 	switch sliName {
 	case Throughput:
-		return "metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+		return "metricSelector=builtin:service.requestCount.total:merge(\"dt.entity.service\"):sum&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case errorRate:
-		return "metricSelector=builtin:service.errors.total.rate:merge(0):avg&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+		return "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case ResponseTimeP50:
-		return "metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case responseTimeP90:
-		return "metricSelector=builtin:service.response.time:merge(0):percentile(90)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(90)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case responseTimeP95:
-		return "metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	default:
 		return "", fmt.Errorf("unsupported SLI %s", sliName)
 	}

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -3,13 +3,14 @@ package monitoring
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 	"github.com/keptn-contrib/dynatrace-service/internal/env"
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	keptnlib "github.com/keptn/go-utils/pkg/lib"
-	"regexp"
-	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -252,10 +253,10 @@ func createKeptnMetricEventDTO(project string, stage string, service string, met
 
 	/*
 		need to map queries used by SLI-service to metric event definition.
-		example: builtin:service.response.time:merge(0):percentile(90)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)
+		example: builtin:service.response.time:merge("dt.entity.service"):percentile(90)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)
 
-		1. split by '?' and get first part => builtin:service.response.time:merge(0):percentile(90)
-		2. split by ':' => builtin:service.response.time | merge(0) | percentile(90) => merge(0) is not needed
+		1. split by '?' and get first part => builtin:service.response.time:merge("dt.entity.service"):percentile(90)
+		2. split by ':' => builtin:service.response.time | merge("dt.entity.service") | percentile(90) => merge("dt.entity.service") is not needed
 		3. first part is the metricId and can be used for the Metric Event API => builtin:service.response.time
 		4. Aggregation is limited to: AVG, COUNT, MAX, MEDIAN, MIN, OF_INTEREST, OF_INTEREST_RATIO, OTHER, OTHER_RATIO, P90, SUM, VALUE
 	*/
@@ -265,10 +266,10 @@ func createKeptnMetricEventDTO(project string, stage string, service string, met
 	}
 
 	query = strings.TrimPrefix(query, "metricSelector=")
-	// 1. split by '?' and get first part => builtin:service.response.time:merge(0):percentile(90)
+	// 1. split by '?' and get first part => builtin:service.response.time:merge("dt.entity.service"):percentile(90)
 	split := strings.Split(query, "?")
 
-	// 2. split by ':' => builtin:service.response.time | merge(0) | percentile(90) => merge(0) is not needed/supported by MetricEvent API
+	// 2. split by ':' => builtin:service.response.time | merge("dt.entity.service") | percentile(90) => merge("dt.entity.service") is not needed/supported by MetricEvent API
 	splittedQuery := strings.Split(split[0], ":")
 
 	if len(splittedQuery) < 2 {

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -251,6 +251,7 @@ var supportedAggregations = [...]string{"avg", "max", "min", "count", "sum", "va
 
 func createKeptnMetricEventDTO(project string, stage string, service string, metric string, query string, condition string, threshold float64, managementZoneID int64) (*dynatrace.MetricEvent, error) {
 
+	// TODO: 2021-09-20: Check what parts are still needed
 	/*
 		need to map queries used by SLI-service to metric event definition.
 		example: builtin:service.response.time:merge("dt.entity.service"):percentile(90)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)

--- a/internal/onboard/service_sync.go
+++ b/internal/onboard/service_sync.go
@@ -2,10 +2,11 @@ package onboard
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/config"
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	keptnlib "github.com/keptn/go-utils/pkg/lib"
-	"time"
 
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 
@@ -300,11 +301,11 @@ func (s *serviceSynchronizer) createSLOResource(serviceName string) error {
 
 func (s *serviceSynchronizer) createSLIResource(serviceName string) error {
 	indicators := make(map[string]string)
-	indicators["throughput"] = fmt.Sprintf("metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
-	indicators["error_rate"] = fmt.Sprintf("metricSelector=builtin:service.errors.total.rate:merge(0):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
-	indicators["response_time_p50"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
-	indicators["response_time_p90"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(0):percentile(90)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
-	indicators["response_time_p95"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
+	indicators["throughput"] = fmt.Sprintf("metricSelector=builtin:service.requestCount.total:merge(\"dt.entity.service\"):sum&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
+	indicators["error_rate"] = fmt.Sprintf("metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
+	indicators["response_time_p50"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
+	indicators["response_time_p90"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(90)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
+	indicators["response_time_p95"] = fmt.Sprintf("metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:%s)", serviceName)
 
 	defaultSLIs := &dynatrace.SLI{
 		SpecVersion: "1.0",

--- a/internal/sli/sli_retrieval.go
+++ b/internal/sli/sli_retrieval.go
@@ -420,6 +420,7 @@ func (ph *Retrieval) generateMetricQueryFromDataExplorer(dataQuery dynatrace.Dat
 	}
 
 	// building the merge aggregator string, e.g: merge(1):merge(0) - or merge(0)
+	// TODO: 2021-09-20: Check for redundant code after update to use dimension keys rather than indexes
 	metricDimensionCount := len(metricDefinition.DimensionDefinitions)
 	metricAggregation := metricDefinition.DefaultAggregation.Type
 	mergeAggregator := ""
@@ -522,6 +523,7 @@ func (ph *Retrieval) generateMetricQueryFromChart(series dynatrace.Series, tileM
 	}
 
 	// building the merge aggregator string, e.g: merge(1):merge(0) - or merge(0)
+	// TODO: 2021-09-20: Check for redundant code after update to use dimension keys rather than indexes
 	metricDimensionCount := len(metricDefinition.DimensionDefinitions)
 	metricAggregation := metricDefinition.DefaultAggregation.Type
 	mergeAggregator := ""
@@ -1326,7 +1328,7 @@ func (ph *Retrieval) executeMetricsQuery(metricsQuery string, unit string, start
 
 			if len(i.Data) != 1 {
 				jsonString, _ := json.Marshal(i)
-				return 0, fmt.Errorf("Dynatrace Metrics API returned %d result values, expected 1 for query: %s.\nPlease ensure the response contains exactly one value (e.g., by using :merge(0):avg for the metric). Here is the output for troubleshooting: %s", len(i.Data), metricsQuery, string(jsonString))
+				return 0, fmt.Errorf("Dynatrace Metrics API returned %d result values, expected 1 for query: %s.\nPlease ensure the response contains exactly one value (e.g., by using :merge(dimension_key):avg for the metric). Here is the output for troubleshooting: %s", len(i.Data), metricsQuery, string(jsonString))
 			}
 
 			return scaleData(metricSelector, unit, i.Data[0].Values[0]), nil

--- a/internal/sli/sli_retrieval.go
+++ b/internal/sli/sli_retrieval.go
@@ -3,13 +3,14 @@ package sli
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
-	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
+	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 
 	log "github.com/sirupsen/logrus"
 
@@ -448,7 +449,7 @@ func (ph *Retrieval) generateMetricQueryFromDataExplorer(dataQuery dynatrace.Dat
 		if doMergeDimension {
 			// this is a dimension we want to merge as it is not split by in the chart
 			log.WithField("dimension", metricDefinition.DimensionDefinitions[metricDimIx].Key).Debug("merging dimension")
-			mergeAggregator = mergeAggregator + fmt.Sprintf(":merge(%d)", metricDimIx)
+			mergeAggregator = mergeAggregator + fmt.Sprintf(":merge(\"%s\")", metricDefinition.DimensionDefinitions[metricDimIx].Key)
 		}
 	}
 
@@ -564,7 +565,7 @@ func (ph *Retrieval) generateMetricQueryFromChart(series dynatrace.Series, tileM
 		if doMergeDimension {
 			// this is a dimension we want to merge as it is not split by in the chart
 			log.WithField("dimension", metricDefinition.DimensionDefinitions[metricDimIx].Name).Debug("merging dimension")
-			mergeAggregator = mergeAggregator + fmt.Sprintf(":merge(%d)", metricDimIx)
+			mergeAggregator = mergeAggregator + fmt.Sprintf(":merge(\"%s\")", metricDefinition.DimensionDefinitions[metricDimIx].Key)
 		}
 	}
 

--- a/internal/sli/sli_retrieval_integration_test.go
+++ b/internal/sli/sli_retrieval_integration_test.go
@@ -2,14 +2,15 @@ package sli
 
 import (
 	"errors"
-	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
-	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
-	"github.com/keptn-contrib/dynatrace-service/internal/test"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
+	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
+	"github.com/keptn-contrib/dynatrace-service/internal/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +23,7 @@ func TestGetSLIValue(t *testing.T) {
 		"nextPageKey": null,
 		"result": [
 			{
-				"metricId": "builtin:service.response.time:merge(0):percentile(50)",
+				"metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)",
 				"data": [
 					{
 						"dimensions": [],
@@ -53,7 +54,7 @@ func TestGetSLIValueWithOldandNewCustomQueryFormat(t *testing.T) {
 		"nextPageKey": null,
 		"result": [
 			{
-				"metricId": "builtin:service.response.time:merge(0):percentile(50)",
+				"metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)",
 				"data": [
 					{
 						"dimensions": [],
@@ -86,7 +87,7 @@ func TestGetSLIValueWithOldandNewCustomQueryFormat(t *testing.T) {
 
 	// overwrite custom queries with the new format (starting with metricSelector=)
 	customQueries := make(map[string]string)
-	customQueries[keptn.ResponseTimeP50] = "metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT),type(SERVICE)"
+	customQueries[keptn.ResponseTimeP50] = "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT),type(SERVICE)"
 
 	start := time.Unix(1571649084, 0).UTC()
 	end := time.Unix(1571649085, 0).UTC()
@@ -97,7 +98,7 @@ func TestGetSLIValueWithOldandNewCustomQueryFormat(t *testing.T) {
 
 	// now do the same but with the new format but with ?metricSelector= in front (the ? is not needed/wanted)
 	customQueries = make(map[string]string)
-	customQueries[keptn.ResponseTimeP50] = "?metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT),type(SERVICE)"
+	customQueries[keptn.ResponseTimeP50] = "?metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT),type(SERVICE)"
 
 	start = time.Unix(1571649084, 0).UTC()
 	end = time.Unix(1571649085, 0).UTC()
@@ -108,7 +109,7 @@ func TestGetSLIValueWithOldandNewCustomQueryFormat(t *testing.T) {
 
 	// now do the same but with the old format ($metricName?scope=...)
 	customQueries = make(map[string]string)
-	customQueries[keptn.ResponseTimeP50] = "builtin:service.response.time:merge(0):percentile(50)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)"
+	customQueries[keptn.ResponseTimeP50] = "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)"
 
 	start = time.Unix(1571649084, 0).UTC()
 	end = time.Unix(1571649085, 0).UTC()
@@ -126,7 +127,7 @@ func TestGetSLIValueWithEmptyResult(t *testing.T) {
     "nextPageKey": null,
 	"result": [
 		{
-			"metricId": "builtin:service.response.time:merge(0):percentile(50)",
+			"metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)",
 			"data": [
 			]
 		}
@@ -195,16 +196,16 @@ func runGetSLIValueTest(okResponse string) (float64, error) {
 
 func TestGetSLIValueWithMV2Prefix(t *testing.T) {
 
-	metricsQuery := "MV2;Percent;metricSelector=builtin:host.cpu.usage:merge(0):avg:names&entitySelector=type(HOST)"
+	metricsQuery := "MV2;Percent;metricSelector=builtin:host.cpu.usage:merge(\"dt.entity.host\"):avg:names&entitySelector=type(HOST)"
 
 	if strings.HasPrefix(metricsQuery, "MV2;") {
 		metricsQuery = metricsQuery[4:]
-		assert.EqualValues(t, metricsQuery, "Percent;metricSelector=builtin:host.cpu.usage:merge(0):avg:names&entitySelector=type(HOST)")
+		assert.EqualValues(t, metricsQuery, "Percent;metricSelector=builtin:host.cpu.usage:merge(\"dt.entity.host\"):avg:names&entitySelector=type(HOST)")
 		queryStartIndex := strings.Index(metricsQuery, ";")
 		metricUnit := metricsQuery[:queryStartIndex]
 		assert.EqualValues(t, metricUnit, "Percent")
 		metricsQuery = metricsQuery[queryStartIndex+1:]
-		assert.EqualValues(t, metricsQuery, "metricSelector=builtin:host.cpu.usage:merge(0):avg:names&entitySelector=type(HOST)")
+		assert.EqualValues(t, metricsQuery, "metricSelector=builtin:host.cpu.usage:merge(\"dt.entity.host\"):avg:names&entitySelector=type(HOST)")
 	}
 }
 
@@ -266,7 +267,7 @@ func TestGetSLISleep(t *testing.T) {
 		"nextPageKey": null,
 		"result": [
 			{
-				"metricId": "builtin:service.response.time:merge(0):percentile(50)",
+				"metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)",
 				"data": [
 					{
 						"dimensions": [],

--- a/internal/sli/testfiles/test_get_metrics_query.json
+++ b/internal/sli/testfiles/test_get_metrics_query.json
@@ -1,7 +1,7 @@
 {
     "result": [
     {
-        "metricId": "builtin:tech.generic.processCount:merge(0):avg:names",
+        "metricId": "builtin:tech.generic.processCount:merge(\"dt.entity.process_group_instance\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -33,7 +33,7 @@
     },
 
     {
-        "metricId": "builtin:tech.generic.mem.workingSetSize:merge(0):avg:names",
+        "metricId": "builtin:tech.generic.mem.workingSetSize:merge(\"dt.entity.process_group_instance\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -50,7 +50,7 @@
     },
     
     {
-        "metricId": "builtin:tech.generic.cpu.usage:merge(0):avg:names",
+        "metricId": "builtin:tech.generic.cpu.usage:merge(\"dt.entity.process_group_instance\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -67,7 +67,7 @@
     },
     
     {
-        "metricId": "builtin:service.errors.server.rate:merge(0):avg:names",
+        "metricId": "builtin:service.errors.server.rate:merge(\"dt.entity.service\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -84,7 +84,7 @@
     },
     
     {
-        "metricId": "builtin:service.requestCount.total:merge(0):value:names",
+        "metricId": "builtin:service.requestCount.total:merge(\"dt.entity.service\"):value:names",
         "data": [
           {
             "dimensions": [
@@ -101,7 +101,7 @@
     },
     
     {
-        "metricId": "builtin:host.cpu.usage:merge(0):avg:names",
+        "metricId": "builtin:host.cpu.usage:merge(\"dt.entity.host\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -118,7 +118,7 @@
     },
     
     {
-        "metricId": "builtin:host.mem.usage:merge(0):avg:names",
+        "metricId": "builtin:host.mem.usage:merge(\"dt.entity.host\"):avg:names",
         "data": [
           {
             "dimensions": [
@@ -135,7 +135,7 @@
     },
     
     {
-        "metricId": "builtin:host.disk.queueLength:merge(1):merge(0):max:names",
+        "metricId": "builtin:host.disk.queueLength:merge(\"dt.entity.disk\"):merge(\"dt.entity.host\"):max:names",
         "data": [
           {
             "dimensions": [
@@ -152,7 +152,7 @@
     },
     
     {
-        "metricId": "builtin:service.nonDbChildCallCount:merge(0):value:names",
+        "metricId": "builtin:service.nonDbChildCallCount:merge(\"dt.entity.service\"):value:names",
         "data": [
           {
             "dimensions": [


### PR DESCRIPTION
This PR removes deprecated `merge(0)` transformations in default SLIs and merge aggregators created from dashboards and replaces them with `merge(dimension_key)` syntax.