### PR TITLE
fixes issues while creating a dashboard

### DIFF
--- a/internal/dynatrace/dashboard.go
+++ b/internal/dynatrace/dashboard.go
@@ -7,13 +7,15 @@ import (
 )
 
 type Dashboard struct {
-	Metadata struct {
-		ConfigurationVersions []int  `json:"configurationVersions"`
-		ClusterVersion        string `json:"clusterVersion"`
-	} `json:"metadata"`
+	Metadata          *Metadata         `json:"metadata,omitempty"`
 	ID                string            `json:"id,omitempty"`
 	DashboardMetadata DashboardMetadata `json:"dashboardMetadata"`
 	Tiles             []Tile            `json:"tiles"`
+}
+
+type Metadata struct {
+	ConfigurationVersions []int  `json:"configurationVersions,omitempty"`
+	ClusterVersion        string `json:"clusterVersion,omitempty"`
 }
 
 type DashboardMetadata struct {
@@ -22,7 +24,7 @@ type DashboardMetadata struct {
 	Owner           string           `json:"owner"`
 	SharingDetails  SharingDetails   `json:"sharingDetails"`
 	DashboardFilter *DashboardFilter `json:"dashboardFilter,omitempty"`
-	Tags            []string         `json:"tags"`
+	Tags            []string         `json:"tags,omitempty"`
 }
 
 type SharingDetails struct {
@@ -43,14 +45,14 @@ type Tile struct {
 	Name                      string              `json:"name"`
 	TileType                  string              `json:"tileType"`
 	Configured                bool                `json:"configured"`
-	Query                     string              `json:"query"`
-	Type                      string              `json:"type"`
-	CustomName                string              `json:"customName"`
-	Markdown                  string              `json:"markdown"`
+	Query                     string              `json:"query,omitempty"`
+	Type                      string              `json:"type,omitempty"`
+	CustomName                string              `json:"customName,omitempty"`
+	Markdown                  string              `json:"markdown,omitempty"`
 	ChartVisible              bool                `json:"chartVisible,omitempty"`
 	Bounds                    Bounds              `json:"bounds"`
 	TileFilter                TileFilter          `json:"tileFilter"`
-	Queries                   []DataExplorerQuery `json:"queries"`
+	Queries                   []DataExplorerQuery `json:"queries,omitempty"`
 	AssignedEntities          []string            `json:"assignedEntities,omitempty"`
 	ExcludeMaintenanceWindows bool                `json:"excludeMaintenanceWindows,omitempty"`
 	FilterConfig              *FilterConfig       `json:"filterConfig,omitempty"`

--- a/internal/dynatrace/dashboard.go
+++ b/internal/dynatrace/dashboard.go
@@ -11,7 +11,7 @@ type Dashboard struct {
 		ConfigurationVersions []int  `json:"configurationVersions"`
 		ClusterVersion        string `json:"clusterVersion"`
 	} `json:"metadata"`
-	ID                string            `json:"id"`
+	ID                string            `json:"id,omitempty"`
 	DashboardMetadata DashboardMetadata `json:"dashboardMetadata"`
 	Tiles             []Tile            `json:"tiles"`
 }

--- a/internal/dynatrace/dynatrace_client.go
+++ b/internal/dynatrace/dynatrace_client.go
@@ -40,10 +40,12 @@ type ConstraintViolations []ConstraintViolation
 func (vs ConstraintViolations) String() string {
 	messages := make([]string, len(vs))
 	for i, v := range vs {
-		messages[i] = v.Message
+		messages[i] = fmt.Sprintf("[path: %s - msg: %s]", v.Path, v.Message)
 	}
 
-	return strings.Join(messages, ", ")
+	return strings.TrimRight(
+		strings.Join(messages, ", "),
+		", ")
 }
 
 type APIError struct {

--- a/internal/monitoring/dashboard_creation.go
+++ b/internal/monitoring/dashboard_creation.go
@@ -122,7 +122,7 @@ func createDynatraceDashboard(projectName string, shipyard keptnv2.Shipyard) *dy
 				Series:         []dynatrace.Series{},
 				ResultMetadata: dynatrace.ResultMetadata{},
 			},
-			FiltersPerEntityType: nil,
+			FiltersPerEntityType: map[string]map[string][]string{},
 		})
 	hostsTile.Bounds = createBounds(38, 0, 152)
 	dtDashboard.Tiles = append(dtDashboard.Tiles, hostsTile)
@@ -201,10 +201,11 @@ func createHostCPULoadTile() dynatrace.Tile {
 		"Host CPU Load",
 		customChartingTileType,
 		&dynatrace.FilterConfig{
-			Type:        "MIXED",
-			CustomName:  "CPU",
-			DefaultName: customChartName,
-			ChartConfig: createTimeSeriesChartConfig("builtin:host.cpu.load", "AVG", "LINE", "HOST"),
+			Type:                 "MIXED",
+			CustomName:           "CPU",
+			DefaultName:          customChartName,
+			ChartConfig:          createTimeSeriesChartConfig("builtin:host.cpu.load", "AVG", "LINE", "HOST"),
+			FiltersPerEntityType: map[string]map[string][]string{},
 		})
 }
 

--- a/internal/sli/dashboard/testdata/test_query_dynatrace_dashboard_dashboard_kqg.json
+++ b/internal/sli/dashboard/testdata/test_query_dynatrace_dashboard_dashboard_kqg.json
@@ -13,17 +13,13 @@
     "sharingDetails": {
       "linkShared": false,
       "published": false
-    },
-    "tags": null
+    }
   },
   "tiles": [
     {
       "name": "Markdown",
       "tileType": "MARKDOWN",
       "configured": true,
-      "query": "",
-      "type": "",
-      "customName": "",
       "markdown": "KQG.Total.Pass=90%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg;KQG.QueryBehavior=ParseOnChange",
       "bounds": {
         "top": 0,
@@ -33,17 +29,13 @@
       },
       "tileFilter": {
         "timeframe": ""
-      },
-      "queries": null
+      }
     },
     {
       "name": "single result tile",
       "tileType": "DATA_EXPLORER",
       "configured": true,
-      "query": "",
-      "type": "",
       "customName": "My single value tile",
-      "markdown": "",
       "bounds": {
         "top": 190,
         "left": 0,


### PR DESCRIPTION
This PR fixes an issue when creating a Dynatrace dashboard while configure monitoring resp. while a new project in Keptn would be set up.
Dynatrace dashboards API would return 400 in this case.

The bug had been introduced while merging the DTOs for dashboards of **dynatrace-service** and **dynatrace-sli-service** recently.