### PR TITLE
Harmonize keptn client creation

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,13 +1,14 @@
 package common
 
 import (
-	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
-	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
 	log "github.com/sirupsen/logrus"
 
@@ -21,21 +22,18 @@ const KEPTNSBRIDGE_LABEL = "Keptns Bridge"
 
 const shipyardController = "SHIPYARD_CONTROLLER"
 const configurationService = "CONFIGURATION_SERVICE"
+const datastore = "DATASTORE"
+
 const defaultShipyardControllerURL = "http://shipyard-controller:8080"
-const defaultConfigurationServiceURL = "http://configuration-service:8080"
 
 // GetConfigurationServiceURL Returns the endpoint to the configuration-service
 func GetConfigurationServiceURL() string {
-	/*
-		// TODO: check previous alternate implementation:
+	return getKeptnServiceURL(configurationService, keptn.ConfigurationServiceURL)
+}
 
-		if os.Getenv("CONFIGURATION_SERVICE") != "" {
-			return os.Getenv("CONFIGURATION_SERVICE")
-		}
-		return "configuration-service:8080"
-	*/
-
-	return getKeptnServiceURL(configurationService, defaultConfigurationServiceURL)
+// GetConfigurationServiceURL Returns the endpoint to the configuration-service
+func GetDatastoreURL() string {
+	return getKeptnServiceURL(datastore, keptn.DatastoreURL)
 }
 
 // GetShipyardControllerURL Returns the endpoint to the shipyard-controller
@@ -44,14 +42,11 @@ func GetShipyardControllerURL() string {
 }
 
 func getKeptnServiceURL(servicename, defaultURL string) string {
-	var baseURL string
 	url, err := keptn.GetServiceEndpoint(servicename)
-	if err == nil {
-		baseURL = url.String()
-	} else {
-		baseURL = defaultURL
+	if err != nil {
+		return defaultURL
 	}
-	return baseURL
+	return url.String()
 }
 
 /**

--- a/internal/event_handler/handler.go
+++ b/internal/event_handler/handler.go
@@ -2,6 +2,7 @@ package event_handler
 
 import (
 	"fmt"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/config"
@@ -13,7 +14,6 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/problem"
 	"github.com/keptn-contrib/dynatrace-service/internal/sli"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
-	keptnapi "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	log "github.com/sirupsen/logrus"
 )
@@ -82,7 +82,7 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 	}
 
 	dtClient := dynatrace.NewClient(dynatraceCredentials)
-	kClient, err := keptnv2.NewKeptn(&event, keptnapi.KeptnOpts{})
+	kClient, err := keptn.NewDefaultClient(event)
 	if err != nil {
 		log.WithError(err).Error("Could not get create Keptn client")
 		return ErrorHandler{err: err}, nil
@@ -90,11 +90,11 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 
 	switch aType := keptnEvent.(type) {
 	case *monitoring.ConfigureMonitoringAdapter:
-		return monitoring.NewConfigureMonitoringEventHandler(keptnEvent.(*monitoring.ConfigureMonitoringAdapter), dtClient, keptn.NewClient(kClient), keptn.NewDefaultResourceClient(), keptn.NewDefaultServiceClient()), nil
+		return monitoring.NewConfigureMonitoringEventHandler(keptnEvent.(*monitoring.ConfigureMonitoringAdapter), dtClient, kClient, keptn.NewDefaultResourceClient(), keptn.NewDefaultServiceClient()), nil
 	case *monitoring.ProjectCreateFinishedAdapter:
-		return monitoring.NewProjectCreateFinishedEventHandler(keptnEvent.(*monitoring.ProjectCreateFinishedAdapter), dtClient, keptn.NewClient(kClient), keptn.NewDefaultResourceClient(), keptn.NewDefaultServiceClient()), nil
+		return monitoring.NewProjectCreateFinishedEventHandler(keptnEvent.(*monitoring.ProjectCreateFinishedAdapter), dtClient, kClient, keptn.NewDefaultResourceClient(), keptn.NewDefaultServiceClient()), nil
 	case *problem.ProblemAdapter:
-		return problem.NewProblemEventHandler(keptnEvent.(*problem.ProblemAdapter), keptn.NewClient(kClient)), nil
+		return problem.NewProblemEventHandler(keptnEvent.(*problem.ProblemAdapter), kClient), nil
 	case *problem.ActionTriggeredAdapter:
 		return problem.NewActionTriggeredEventHandler(keptnEvent.(*problem.ActionTriggeredAdapter), dtClient, keptn.NewDefaultEventClient(), dynatraceConfig.AttachRules), nil
 	case *problem.ActionStartedAdapter:
@@ -102,7 +102,7 @@ func NewEventHandler(event cloudevents.Event) (DynatraceEventHandler, error) {
 	case *problem.ActionFinishedAdapter:
 		return problem.NewActionFinishedEventHandler(keptnEvent.(*problem.ActionFinishedAdapter), dtClient, keptn.NewDefaultEventClient(), dynatraceConfig.AttachRules), nil
 	case *sli.GetSLITriggeredAdapter:
-		return sli.NewGetSLITriggeredHandler(keptnEvent.(*sli.GetSLITriggeredAdapter), dtClient, keptn.NewClient(kClient), keptn.NewDefaultResourceClient(), secretName, dynatraceConfig.Dashboard), nil
+		return sli.NewGetSLITriggeredHandler(keptnEvent.(*sli.GetSLITriggeredAdapter), dtClient, kClient, keptn.NewDefaultResourceClient(), secretName, dynatraceConfig.Dashboard), nil
 	case *deployment.DeploymentFinishedAdapter:
 		return deployment.NewDeploymentFinishedEventHandler(keptnEvent.(*deployment.DeploymentFinishedAdapter), dtClient, keptn.NewDefaultEventClient(), dynatraceConfig.AttachRules), nil
 	case *deployment.TestTriggeredAdapter:

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	"github.com/keptn-contrib/dynatrace-service/internal/common"
+	keptnapi "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
@@ -60,6 +63,18 @@ func NewClient(client *keptnv2.Keptn) *Client {
 	return &Client{
 		client: client,
 	}
+}
+
+func NewDefaultClient(event event.Event) (*Client, error) {
+	keptnOpts := keptnapi.KeptnOpts{
+		ConfigurationServiceURL: common.GetConfigurationServiceURL(),
+		DatastoreURL:            common.GetDatastoreURL(),
+	}
+	kClient, err := keptnv2.NewKeptn(&event, keptnOpts)
+	if err != nil {
+		return nil, fmt.Errorf("could not create default Keptn client: %v", err)
+	}
+	return NewClient(kClient), nil
 }
 
 func (c *Client) GetCustomQueries(project string, stage string, service string) (*CustomQueries, error) {


### PR DESCRIPTION
Introduces `keptn.NewDefaultClient()` that creates a Keptn client that uses the same service URLs used other places in the code.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>