### PR TITLE
No fallback to default SLIs when custom SLIs are defined (in sli.yaml) 

### DIFF
--- a/internal/dynatrace/metrics_client.go
+++ b/internal/dynatrace/metrics_client.go
@@ -39,6 +39,7 @@ type MetricsQueryResult struct {
 type MetricQueryResultValues struct {
 	MetricID string                     `json:"metricId"`
 	Data     []MetricQueryResultNumbers `json:"data"`
+	Warnings []string                   `json:"warnings,omitempty"`
 }
 
 type MetricQueryResultNumbers struct {

--- a/internal/dynatrace/metrics_client.go
+++ b/internal/dynatrace/metrics_client.go
@@ -3,8 +3,6 @@ package dynatrace
 import (
 	"encoding/json"
 	"errors"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const metricsPath = "/api/v2/metrics"
@@ -80,10 +78,7 @@ func (mc *MetricsClient) GetByID(metricID string) (*MetricDefinition, error) {
 
 // GetByQuery executes the passed Metrics API Call, validates that the call returns data and returns the data set
 func (mc *MetricsClient) GetByQuery(metricsQuery string) (*MetricsQueryResult, error) {
-	path := metricsPath + "/query?" + metricsQuery
-	log.WithField("query", mc.client.Credentials().Tenant+path).Debug("Final Query")
-
-	body, err := mc.client.Get(path)
+	body, err := mc.client.Get(metricsPath + "/query?" + metricsQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dynatrace/problems_v2_client_test.go
+++ b/internal/dynatrace/problems_v2_client_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestExecuteGetDynatraceProblems(t *testing.T) {
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddStartsWith("/api/v2/problems", "./testdata/test_get_problems.json")
 
 	dtClient, _, teardown := createDynatraceClient(handler)

--- a/internal/dynatrace/security_problems_client_test.go
+++ b/internal/dynatrace/security_problems_client_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestExecuteGetDynatraceSecurityProblems(t *testing.T) {
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddStartsWith("/api/v2/securityProblems", "./testdata/test_get_securityproblems.json")
 
 	dtClient, _, teardown := createDynatraceClient(handler)

--- a/internal/dynatrace/slo_client_test.go
+++ b/internal/dynatrace/slo_client_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestExecuteGetDynatraceSLO(t *testing.T) {
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddStartsWith("/api/v2/slo", "./testdata/test_get_slo_id.json")
 
 	dtClient, _, teardown := createDynatraceClient(handler)

--- a/internal/dynatrace/usql_client.go
+++ b/internal/dynatrace/usql_client.go
@@ -3,7 +3,6 @@ package dynatrace
 import (
 	"encoding/json"
 	"errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const usqlPath = "/api/v1/userSessionQueryLanguage/table"
@@ -27,10 +26,7 @@ func NewUSQLClient(client ClientInterface) *USQLClient {
 
 // GetByQuery executes the passed USQL API query, validates that the call returns data and returns the data set
 func (uc *USQLClient) GetByQuery(usql string) (*DTUSQLResult, error) {
-	path := usqlPath + "?" + usql
-	log.WithField("query", uc.client.Credentials().Tenant+path).Debug("Final USQL Query")
-
-	body, err := uc.client.Get(path)
+	body, err := uc.client.Get(usqlPath + "?" + usql)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -49,6 +49,26 @@ func (cq *CustomQueries) GetQueryByNameOrDefault(sliName string) (string, error)
 	return defaultQuery, nil
 }
 
+func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string, error) {
+	query, exists := cq.values[sliName]
+	if exists {
+		return query, nil
+	}
+
+	// there are custom SLIs defined, but we could not match it
+	if len(cq.values) != 0 {
+		return "", fmt.Errorf("SLI definition for '%s' was not found", sliName)
+	}
+
+	// no custom SLIs defined - so we fallback to using defaults
+	defaultQuery, err := getDefaultQuery(sliName)
+	if err != nil {
+		return "", err
+	}
+
+	return defaultQuery, nil
+}
+
 type ClientInterface interface {
 	GetCustomQueries(project string, stage string, service string) (*CustomQueries, error)
 	GetShipyard() (*keptnv2.Shipyard, error)

--- a/internal/sli/dashboard/dashboard_querying_test.go
+++ b/internal/sli/dashboard/dashboard_querying_test.go
@@ -17,7 +17,7 @@ const dashboardURL = "/api/config/v1/dashboards"
 func TestQueryDynatraceDashboardForSLIs(t *testing.T) {
 	keptnEvent := createKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	// we handle these if the URLs are a full match
 	handler.AddExact("/api/config/v1/dashboards", "./testdata/test_get_dashboards.json")
 	handler.AddExact("/api/config/v1/dashboards/12345678-1111-4444-8888-123456789012", "./testdata/test_get_dashboards_id.json")
@@ -95,7 +95,7 @@ func TestQueryingOfDashboardNecessaryDueToNotSpecifiedButStoredDashboardInKeptnW
 	ev := &test.EventData{}
 
 	// we add a handler to simulate a failing dashboards API request (401 in this case)
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExactError(dashboardURL, http.StatusUnauthorized, "./testdata/dynatrace_missing_authorization_error.json")
 
 	// we don't care about the content of the dashboard here, because it just should not be empty!
@@ -120,7 +120,7 @@ func TestQueryingOfDashboardNecessaryDueToNotSpecifiedButStoredDashboardInKeptnW
 	ev := &test.EventData{}
 
 	// we add a handler to simulate an successful Dashboards API request in this case.
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact(dashboardURL, "./testdata/test_query_dynatrace_dashboard_dashboards.json")
 
 	// we don't care about the content of the dashboard here, because it just should not be empty!
@@ -151,7 +151,7 @@ func TestQueryingOfDashboardNecessaryDueToNotSpecifiedButStoredDashboardInKeptnW
 	const storedDashboardFile = "./testdata/test_query_dynatrace_dashboard_dashboard_kqg.json"
 
 	// we add a handle to simulate an successful Dashboards API request in this case.
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact(dashboardURL, "./testdata/test_query_dynatrace_dashboard_dashboards_kqg.json")
 	handler.AddExact(dashboardURL+"/"+matchingDashboardID, storedDashboardFile)
 
@@ -196,7 +196,7 @@ func TestRetrieveDashboardWithValidIDAndStoredDashboardInKeptnIsTheSame(t *testi
 	const storedDashboardFile = "./testdata/test_query_dynatrace_dashboard_dashboard_kqg.json"
 
 	// we add a handle to simulate an successful Dashboards API request in this case.
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact(dashboardURL+"/"+dashboardID, storedDashboardFile)
 
 	dashboardContent, err := ioutil.ReadFile(storedDashboardFile)
@@ -233,7 +233,7 @@ func TestRetrieveDashboardWithUnknownButValidID(t *testing.T) {
 	const dashboardID = "e03f4be0-4712-4f12-96ee-8c486d001e9c"
 
 	// we add a handler to simulate a very concrete 404 Dashboards API request/response in this case.
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExactError(dashboardURL+"/"+dashboardID, http.StatusNotFound, "./testdata/test_query_dynatrace_dashboard_dashboard_id_not_found.json")
 
 	// we also do not care about the dashboard that would be returned by keptn
@@ -262,7 +262,7 @@ func TestRetrieveDashboardWithInvalidID(t *testing.T) {
 	const dashboardID = "definitely-invalid-uuid"
 
 	// we add a handler to simulate a very concrete 400 Dashboards API request/response in this case.
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExactError(dashboardURL+"/"+dashboardID, http.StatusBadRequest, "./testdata/test_query_dynatrace_dashboard_dashboard_id_not_valid.json")
 
 	// we also do not care about the dashboard that would be returned by keptn

--- a/internal/sli/dashboard/dashboard_retrieval_test.go
+++ b/internal/sli/dashboard/dashboard_retrieval_test.go
@@ -13,7 +13,7 @@ import (
 func TestFindDynatraceDashboardSuccess(t *testing.T) {
 	keptnEvent := createKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact("/api/config/v1/dashboards", "./testdata/test_get_dashboards.json")
 
 	dh, teardown := createDashboardRetrieval(keptnEvent, handler)
@@ -33,7 +33,7 @@ func TestFindDynatraceDashboardSuccess(t *testing.T) {
 func TestFindDynatraceDashboardNoneExistingDashboard(t *testing.T) {
 	keptnEvent := createKeptnEvent("BAD PROJECT", QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact("/api/config/v1/dashboards", "./testdata/test_get_dashboards.json")
 
 	dh, teardown := createDashboardRetrieval(keptnEvent, handler)
@@ -53,7 +53,7 @@ func TestFindDynatraceDashboardNoneExistingDashboard(t *testing.T) {
 func TestLoadDynatraceDashboardWithQUERY(t *testing.T) {
 	keptnEvent := createKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact("/api/config/v1/dashboards", "./testdata/test_get_dashboards.json")
 	handler.AddExact("/api/config/v1/dashboards/12345678-1111-4444-8888-123456789012", "./testdata/test_get_dashboards_id.json")
 
@@ -79,7 +79,7 @@ func TestLoadDynatraceDashboardWithQUERY(t *testing.T) {
 func TestLoadDynatraceDashboardWithID(t *testing.T) {
 	keptnEvent := createKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact("/api/config/v1/dashboards/12345678-1111-4444-8888-123456789012", "./testdata/test_get_dashboards_id.json")
 
 	dh, teardown := createDashboardRetrieval(keptnEvent, handler)
@@ -104,7 +104,7 @@ func TestLoadDynatraceDashboardWithID(t *testing.T) {
 func TestLoadDynatraceDashboardWithEmptyDashboard(t *testing.T) {
 	keptnEvent := createKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE)
 
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 
 	dh, teardown := createDashboardRetrieval(keptnEvent, handler)
 	defer teardown()

--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -286,8 +286,7 @@ func (eh *GetSLIEventHandler) retrieveMetrics() error {
 		if err != nil {
 			// if we cannot retrieve any, we continue anyway
 			log.WithError(err).Errorf("could not retrieve custom queries: %v", err)
-			projectCustomQueries = keptn.NewEmptyCustomQueries()
-			//return eh.sendGetSLIFinishedEvent(nil, err)
+			return eh.sendGetSLIFinishedEvent(nil, err)
 		}
 
 		queryProcessing := query.NewProcessing(eh.dtClient, eh.event, eh.event.GetCustomSLIFilters(), projectCustomQueries, startUnix, endUnix)

--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -287,6 +287,7 @@ func (eh *GetSLIEventHandler) retrieveMetrics() error {
 			// if we cannot retrieve any, we continue anyway
 			log.WithError(err).Errorf("could not retrieve custom queries: %v", err)
 			projectCustomQueries = keptn.NewEmptyCustomQueries()
+			//return eh.sendGetSLIFinishedEvent(nil, err)
 		}
 
 		queryProcessing := query.NewProcessing(eh.dtClient, eh.event, eh.event.GetCustomSLIFilters(), projectCustomQueries, startUnix, endUnix)

--- a/internal/sli/get_sli_triggered_event_handler_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_test.go
@@ -1,0 +1,69 @@
+package sli
+
+import (
+	"encoding/json"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/keptn-contrib/dynatrace-service/internal/test"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
+//
+// prerequisites:
+// * no (previous) dashboard is stored in Keptn
+// * a file called 'dynatrace/sli.yaml' exists and a SLI that we would want to evaluate (as defined in the slo.yaml) is defined
+func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
+
+	const indicator = "response_time_p95"
+
+	ev := &getSLIEventData{
+		project:    "sockshop",
+		stage:      "staging",
+		service:    "carts",
+		indicators: []string{indicator}, // we need this to check later on in the custom queries
+	}
+
+	handler := test.NewFileBasedURLHandler(t)
+	handler.AddExact("/api/v2/metrics/query?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000", "./testdata/response_time_p95_200_1_result.json")
+
+	kClient := &keptnClientMock{
+		customQueries: map[string]string{
+			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+		},
+	}
+
+	eh, _, teardown := createGetSLIEventHandler(ev, handler, kClient)
+	defer teardown()
+
+	err := eh.retrieveMetrics()
+
+	expectedResult := &keptnv2.SLIResult{
+		Metric:  indicator,
+		Value:   12.439619479902443, // div by 1000 from dynatrace API result!
+		Success: true,
+	}
+
+	assert.NoError(t, err)
+	assertThatEventsHaveSuccessPayload(t, expectedResult, kClient.eventSink)
+}
+
+func assertThatEventsHaveSuccessPayload(t *testing.T, expectedResult *keptnv2.SLIResult, events []*cloudevents.Event) {
+	assert.EqualValues(t, 2, len(events))
+
+	assert.EqualValues(t, keptnv2.GetStartedEventType(keptnv2.GetSLITaskName), events[0].Type())
+	assert.EqualValues(t, keptnv2.GetFinishedEventType(keptnv2.GetSLITaskName), events[1].Type())
+
+	var data keptnv2.GetSLIFinishedEventData
+	err := json.Unmarshal(events[1].Data(), &data)
+	if err != nil {
+		t.Fatalf("could not parse event payload correctly: %s", err)
+	}
+
+	assert.EqualValues(t, keptnv2.ResultPass, data.Result)
+	assert.EqualValues(t, keptnv2.StatusSucceeded, data.Status)
+
+	assert.EqualValues(t, 1, len(data.GetSLI.IndicatorValues))
+	assert.EqualValues(t, expectedResult, data.GetSLI.IndicatorValues[0])
+}

--- a/internal/sli/get_sli_triggered_event_handler_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_test.go
@@ -55,6 +55,100 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreInvalidYAML(t *testing.T) {
 // prerequisites:
 // * no (previous) dashboard is stored in Keptn
 // * a file called 'dynatrace/sli.yaml' exists and a SLI that we would want to evaluate (as defined in the slo.yaml) is defined
+// * the defined SLI is valid YAML, Dynatrace can process the query correctly (200), but returns 0 results and a warning
+//   - e.g. misspelled dimension key in merge transformation
+func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsAndWarning(t *testing.T) {
+	const indicator = "response_time_p95"
+
+	ev := &getSLIEventData{
+		project:    "sockshop",
+		stage:      "staging",
+		service:    "carts",
+		indicators: []string{indicator}, // we need this to check later on in the custom queries
+	}
+
+	// error here: merge(dt.entity.services)
+	handler := test.NewFileBasedURLHandler(t)
+	handler.AddExact(
+		"/api/v2/metrics/query?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.services%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
+		"./testdata/response_time_p95_200_0_result_warning_entity-selector.json")
+
+	// error here as well: merge("dt.entity.services")
+	kClient := &keptnClientMock{
+		customQueries: map[string]string{
+			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.services\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+		},
+	}
+
+	eh, _, teardown := createGetSLIEventHandler(ev, handler, kClient)
+	defer teardown()
+
+	err := eh.retrieveMetrics()
+
+	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+		assert.EqualValues(t, indicator, actual.Metric)
+		assert.EqualValues(t, 0, actual.Value)
+		assert.EqualValues(t, false, actual.Success)
+		assert.Contains(t, actual.Message, "no result values")
+		assert.Contains(t, actual.Message, "Warning")
+	}
+
+	assert.NoError(t, err)
+	assertThatEventHasExpectedPayloadWithMatchingFunc(t, assertionsFunc, kClient.eventSink)
+}
+
+// In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
+//
+// prerequisites:
+// * no (previous) dashboard is stored in Keptn
+// * a file called 'dynatrace/sli.yaml' exists and a SLI that we would want to evaluate (as defined in the slo.yaml) is defined
+// * the defined SLI is valid YAML, Dynatrace can process the query correctly (200), but returns 0 results and no warning
+//	 - e.g. misspelled tag name
+func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(t *testing.T) {
+	const indicator = "response_time_p95"
+
+	ev := &getSLIEventData{
+		project:    "sockshop",
+		stage:      "staging",
+		service:    "carts",
+		indicators: []string{indicator}, // we need this to check later on in the custom queries
+	}
+
+	// error here: tag(keptn_project:stagin)
+	handler := test.NewFileBasedURLHandler(t)
+	handler.AddExact(
+		"/api/v2/metrics/query?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astagin%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
+		"./testdata/response_time_p95_200_0_result_wrong-tag.json")
+
+	// error here as well: tag(keptn_project:stagin)
+	kClient := &keptnClientMock{
+		customQueries: map[string]string{
+			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:stagin)",
+		},
+	}
+
+	eh, _, teardown := createGetSLIEventHandler(ev, handler, kClient)
+	defer teardown()
+
+	err := eh.retrieveMetrics()
+
+	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+		assert.EqualValues(t, indicator, actual.Metric)
+		assert.EqualValues(t, 0, actual.Value)
+		assert.EqualValues(t, false, actual.Success)
+		assert.Contains(t, actual.Message, "no result values")
+		assert.NotContains(t, actual.Message, "Warning")
+	}
+
+	assert.NoError(t, err)
+	assertThatEventHasExpectedPayloadWithMatchingFunc(t, assertionsFunc, kClient.eventSink)
+}
+
+// In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
+//
+// prerequisites:
+// * no (previous) dashboard is stored in Keptn
+// * a file called 'dynatrace/sli.yaml' exists and a SLI that we would want to evaluate (as defined in the slo.yaml) is defined
 func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 
 	const indicator = "response_time_p95"
@@ -67,7 +161,9 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 	}
 
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExact("/api/v2/metrics/query?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000", "./testdata/response_time_p95_200_1_result.json")
+	handler.AddExact(
+		"/api/v2/metrics/query?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
+		"./testdata/response_time_p95_200_1_result.json")
 
 	kClient := &keptnClientMock{
 		customQueries: map[string]string{
@@ -91,6 +187,20 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 }
 
 func assertThatEventHasExpectedPayload(t *testing.T, expectedResult *keptnv2.SLIResult, events []*cloudevents.Event) {
+	data := assertThatEventsAreThere(t, events)
+
+	assert.EqualValues(t, 1, len(data.GetSLI.IndicatorValues))
+	assert.EqualValues(t, expectedResult, data.GetSLI.IndicatorValues[0])
+}
+
+func assertThatEventHasExpectedPayloadWithMatchingFunc(t *testing.T, assertionsFunc func(*testing.T, *keptnv2.SLIResult), events []*cloudevents.Event) {
+	data := assertThatEventsAreThere(t, events)
+
+	assert.EqualValues(t, 1, len(data.GetSLI.IndicatorValues))
+	assertionsFunc(t, data.GetSLI.IndicatorValues[0])
+}
+
+func assertThatEventsAreThere(t *testing.T, events []*cloudevents.Event) *keptnv2.GetSLIFinishedEventData {
 	assert.EqualValues(t, 2, len(events))
 
 	assert.EqualValues(t, keptnv2.GetStartedEventType(keptnv2.GetSLITaskName), events[0].Type())
@@ -105,6 +215,5 @@ func assertThatEventHasExpectedPayload(t *testing.T, expectedResult *keptnv2.SLI
 	assert.EqualValues(t, keptnv2.ResultPass, data.Result)
 	assert.EqualValues(t, keptnv2.StatusSucceeded, data.Status)
 
-	assert.EqualValues(t, 1, len(data.GetSLI.IndicatorValues))
-	assert.EqualValues(t, expectedResult, data.GetSLI.IndicatorValues[0])
+	return &data
 }

--- a/internal/sli/get_sli_triggered_event_handler_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_test.go
@@ -27,7 +27,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 	// error here in the misspelled indicator:
 	kClient := &keptnClientMock{
 		customQueries: map[string]string{
-			"response_time_p59": "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+			"response_time_p59": "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}
 
@@ -178,7 +178,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreDefinedButEmpty(t *testing.T) {
 
 	// no custom queries defined here
 	// currently this could have 2 reasons: EITHER no sli.yaml file available OR no indicators defined in such a file)
-	// TODO 2021-09-29: we should be able to differentiate between 'not there' and 'not SLIs defined' - the latter could be intentional
+	// TODO 2021-09-29: we should be able to differentiate between 'not there' and 'no SLIs defined' - the latter could be intentional
 	kClient := &keptnClientMock{}
 
 	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {

--- a/internal/sli/query/query_processing.go
+++ b/internal/sli/query/query_processing.go
@@ -199,10 +199,17 @@ func (p *Processing) executeMetricsQuery(metricsQuery string, metricUnit string,
 	for _, i := range result.Result {
 
 		if IsMatchingMetricID(i.MetricID, metricSelector) {
-
 			if len(i.Data) != 1 {
+				if len(i.Data) == 0 {
+					if len(i.Warnings) > 0 {
+						return 0, fmt.Errorf("Dynatrace Metrics API returned no result values, expected 1 for query: %s. Warning: %s", metricsQuery, strings.Join(i.Warnings, ", "))
+					}
+
+					return 0, fmt.Errorf("Dynatrace Metrics API returned no result values, expected 1 for query: %s. Please ensure the response contains exactly one value", metricsQuery)
+				}
+
 				jsonString, _ := json.Marshal(i)
-				return 0, fmt.Errorf("Dynatrace Metrics API returned %d result values, expected 1 for query: %s.\nPlease ensure the response contains exactly one value (e.g., by using :merge(dimension_key):avg for the metric). Here is the output for troubleshooting: %s", len(i.Data), metricsQuery, string(jsonString))
+				return 0, fmt.Errorf("Dynatrace Metrics API returned %d result values, expected 1 for query: %s. Please ensure the response contains exactly one value (e.g., by using :merge(dimension_key):avg for the metric). Here is the output for troubleshooting: %s", len(i.Data), metricsQuery, string(jsonString))
 			}
 
 			return unit.ScaleData(metricSelector, metricUnit, i.Data[0].Values[0]), nil

--- a/internal/sli/query/query_processing.go
+++ b/internal/sli/query/query_processing.go
@@ -38,11 +38,11 @@ func NewProcessing(client dynatrace.ClientInterface, eventData adapter.EventCont
 // GetSLIValue queries a single metric value from Dynatrace API.
 // Can handle both Metric Queries as well as USQL
 func (p *Processing) GetSLIValue(name string) (float64, error) {
-
 	// first we get the query from the SLI configuration based on its logical name
-	sliQuery, err := p.customQueries.GetQueryByNameOrDefault(name)
+	// no default values here anymore if indicator could not be matched (e.g. due to a misspelling) and custom SLIs were defined
+	sliQuery, err := p.customQueries.GetQueryByNameOrDefaultIfEmpty(name)
 	if err != nil {
-		return 0, fmt.Errorf("error when fetching SLI config for %s %s", name, err.Error())
+		return 0, err
 	}
 
 	log.WithFields(

--- a/internal/sli/query/query_processing.go
+++ b/internal/sli/query/query_processing.go
@@ -202,7 +202,7 @@ func (p *Processing) executeMetricsQuery(metricsQuery string, metricUnit string,
 			if len(i.Data) != 1 {
 				if len(i.Data) == 0 {
 					if len(i.Warnings) > 0 {
-						return 0, fmt.Errorf("Dynatrace Metrics API returned no result values, expected 1 for query: %s. Warning: %s", metricsQuery, strings.Join(i.Warnings, ", "))
+						return 0, fmt.Errorf("Warning: %s. Dynatrace Metrics API returned no result values, expected 1 for query: %s", strings.Join(i.Warnings, ", "), metricsQuery)
 					}
 
 					return 0, fmt.Errorf("Dynatrace Metrics API returned no result values, expected 1 for query: %s. Please ensure the response contains exactly one value", metricsQuery)

--- a/internal/sli/query/query_processing_test.go
+++ b/internal/sli/query/query_processing_test.go
@@ -50,7 +50,6 @@ func TestGetSLIValue(t *testing.T) {
 	value, err := runGetSLIValueTest(handler)
 
 	assert.NoError(t, err)
-
 	assert.InDelta(t, 8.43340, value, 0.001)
 }
 
@@ -288,8 +287,8 @@ func TestGetSLISleep(t *testing.T) {
 
 	value, err := dh.GetSLIValue(keptn.ResponseTimeP50)
 
+	assert.NoError(t, err)
 	assert.InDelta(t, 8.43340, value, 0.001)
-	assert.Nil(t, err)
 }
 
 // Tests the behaviour of the GetSLIValue function in case of a HTTP 400 return code
@@ -308,8 +307,8 @@ func TestGetSLIValueWithErrorResponse(t *testing.T) {
 
 	value, err := dh.GetSLIValue(keptn.Throughput)
 
+	assert.Error(t, err)
 	assert.EqualValues(t, 0.0, value)
-	assert.NotNil(t, err, nil)
 }
 
 func TestGetSLIValueForIndicator(t *testing.T) {

--- a/internal/sli/query/query_processing_test.go
+++ b/internal/sli/query/query_processing_test.go
@@ -44,7 +44,7 @@ func TestGetSLIValue(t *testing.T) {
 		]
 	}`
 
-	handler := test.NewPayloadBasedURLHandler()
+	handler := test.NewPayloadBasedURLHandler(t)
 	handler.AddStartsWith(metricAPIURL, []byte(okResponse))
 
 	value, err := runGetSLIValueTest(handler)
@@ -78,7 +78,7 @@ func TestGetSLIValueWithOldAndNewCustomQueryFormat(t *testing.T) {
 		]
 	}`
 
-	handler := test.NewPayloadBasedURLHandler()
+	handler := test.NewPayloadBasedURLHandler(t)
 	handler.AddStartsWith(metricAPIURL, []byte(okResponse))
 
 	httpClient, teardown := test.CreateHTTPClient(handler)
@@ -123,8 +123,8 @@ func TestGetSLIValueWithEmptyResult(t *testing.T) {
 		]
 	}`
 
-	handler := test.NewPayloadBasedURLHandler()
-	handler.AddExact(metricAPIURL, []byte(okResponse))
+	handler := test.NewPayloadBasedURLHandler(t)
+	handler.AddStartsWith(metricAPIURL, []byte(okResponse))
 
 	value, err := runGetSLIValueTest(handler)
 
@@ -157,8 +157,8 @@ func TestGetSLIValueWithoutExpectedMetric(t *testing.T) {
 		]
 	}`
 
-	handler := test.NewPayloadBasedURLHandler()
-	handler.AddExact(metricAPIURL, []byte(okResponse))
+	handler := test.NewPayloadBasedURLHandler(t)
+	handler.AddStartsWith(metricAPIURL, []byte(okResponse))
 
 	value, err := runGetSLIValueTest(handler)
 
@@ -273,8 +273,8 @@ func TestGetSLISleep(t *testing.T) {
 		]
 	}`
 
-	handler := test.NewPayloadBasedURLHandler()
-	handler.AddExact(metricAPIURL, []byte(okResponse))
+	handler := test.NewPayloadBasedURLHandler(t)
+	handler.AddStartsWith(metricAPIURL, []byte(okResponse))
 
 	httpClient, teardown := test.CreateHTTPClient(handler)
 	defer teardown()
@@ -294,7 +294,7 @@ func TestGetSLISleep(t *testing.T) {
 
 // Tests the behaviour of the GetSLIValue function in case of a HTTP 400 return code
 func TestGetSLIValueWithErrorResponse(t *testing.T) {
-	handler := test.NewPayloadBasedURLHandler()
+	handler := test.NewPayloadBasedURLHandler(t)
 	handler.AddStartsWithError(metricAPIURL, http.StatusBadRequest, []byte{})
 
 	httpClient, teardown := test.CreateHTTPClient(handler)
@@ -313,7 +313,7 @@ func TestGetSLIValueWithErrorResponse(t *testing.T) {
 }
 
 func TestGetSLIValueForIndicator(t *testing.T) {
-	handler := test.NewFileBasedURLHandler()
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddStartsWith("/api/v2/slo", "./testdata/test_get_slo_id.json")
 	handler.AddStartsWith("/api/v2/problems", "./testdata/test_get_problems.json")
 	handler.AddStartsWith("/api/v2/securityProblems", "./testdata/test_get_securityproblems.json")

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -1,0 +1,196 @@
+package sli
+
+import (
+	"fmt"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
+	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
+	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
+	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
+	"github.com/keptn-contrib/dynatrace-service/internal/test"
+	keptnapi "github.com/keptn/go-utils/pkg/lib"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"net/http"
+	"sync"
+)
+
+func createGetSLIEventHandler(keptnEvent GetSLITriggeredAdapterInterface, handler http.Handler, kClient keptn.ClientInterface) (*GetSLIEventHandler, string, func()) {
+	httpClient, url, teardown := test.CreateHTTPSClient(handler)
+
+	dtCredentials := &credentials.DTCredentials{
+		Tenant:   url,
+		ApiToken: "test",
+	}
+
+	eh := &GetSLIEventHandler{
+		event:          keptnEvent,
+		dtClient:       dynatrace.NewClientWithHTTP(dtCredentials, httpClient),
+		kClient:        kClient,
+		resourceClient: &resourceClientMock{},
+		dashboard:      "",          // we do not want to query a dashboard, so we leave it empty (and have no dashboard stored)
+		secretName:     "dynatrace", // we do not need this string
+	}
+
+	return eh, url, teardown
+}
+
+type getSLIEventData struct {
+	context string
+	source  string
+	event   string
+
+	project            string
+	stage              string
+	service            string
+	deployment         string
+	testStrategy       string
+	deploymentStrategy string
+
+	labels map[string]string
+
+	indicators      []string
+	customFilters   []*keptnv2.SLIFilter
+	notForDynatrace bool
+	sliStart        string
+	sliEnd          string
+}
+
+func (e *getSLIEventData) GetShKeptnContext() string {
+	return e.context
+}
+
+func (e *getSLIEventData) GetEvent() string {
+	return e.event
+}
+
+func (e *getSLIEventData) GetSource() string {
+	return e.source
+}
+
+func (e *getSLIEventData) GetProject() string {
+	return e.project
+}
+
+func (e *getSLIEventData) GetStage() string {
+	return e.stage
+}
+
+func (e *getSLIEventData) GetService() string {
+	return e.service
+}
+
+func (e *getSLIEventData) GetDeployment() string {
+	return e.deployment
+}
+
+func (e *getSLIEventData) GetTestStrategy() string {
+	return e.testStrategy
+}
+
+func (e *getSLIEventData) GetDeploymentStrategy() string {
+	return e.deploymentStrategy
+}
+
+func (e *getSLIEventData) GetLabels() map[string]string {
+	return e.labels
+}
+
+func (e *getSLIEventData) GetEventID() string {
+	return "some-event-id"
+}
+
+func (e *getSLIEventData) IsNotForDynatrace() bool {
+	return e.notForDynatrace
+}
+
+func (e *getSLIEventData) GetSLIStart() string {
+	if e.sliStart == "" {
+		return "2021-09-28T13:16:39.000Z"
+	}
+
+	return e.sliStart
+}
+
+func (e *getSLIEventData) GetSLIEnd() string {
+	if e.sliEnd == "" {
+		return "2021-09-28T13:21:39.000Z"
+	}
+
+	return e.sliEnd
+}
+
+func (e *getSLIEventData) GetIndicators() []string {
+	return e.indicators
+}
+
+func (e *getSLIEventData) GetCustomSLIFilters() []*keptnv2.SLIFilter {
+	return e.customFilters
+}
+
+func (e *getSLIEventData) AddLabel(name string, value string) {
+	if e.labels == nil {
+		e.labels = make(map[string]string)
+	}
+
+	e.labels[name] = value
+}
+
+type resourceClientMock struct{}
+
+func (m *resourceClientMock) GetSLOs(project string, stage string, service string) (*keptnapi.ServiceLevelObjectives, error) {
+	panic("GetSLOs() should not be needed in this mock!")
+}
+
+func (m *resourceClientMock) UploadSLI(project string, stage string, service string, sli *dynatrace.SLI) error {
+	panic("UploadSLI() should not be needed in this mock!")
+}
+
+func (m *resourceClientMock) UploadSLOs(project string, stage string, service string, dashboardSLOs *keptnapi.ServiceLevelObjectives) error {
+	panic("UploadSLOs() should not be needed in this mock!")
+}
+
+func (m *resourceClientMock) GetDashboard(project string, stage string, service string) (string, error) {
+	// we do not want to have any dashboard stored, so return empty string
+	return "", nil
+}
+
+func (m *resourceClientMock) UploadDashboard(project string, stage string, service string, dashboard *dynatrace.Dashboard) error {
+	panic("UploadDashboard() should not be needed in this mock!")
+}
+
+type keptnClientMock struct {
+	eventSink     []*cloudevents.Event
+	customQueries map[string]string
+	mutex         sync.Mutex
+}
+
+func (m *keptnClientMock) GetCustomQueries(project string, stage string, service string) (*keptn.CustomQueries, error) {
+	if m.customQueries == nil {
+		return keptn.NewEmptyCustomQueries(), nil
+	}
+
+	return keptn.NewCustomQueries(m.customQueries), nil
+}
+
+func (m *keptnClientMock) GetShipyard() (*keptnv2.Shipyard, error) {
+	panic("GetShipyard() should not be needed in this mock!")
+}
+
+func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// simulate errors while creating cloud event
+	if factory == nil {
+		return fmt.Errorf("could not send create cloud event")
+	}
+
+	ce, err := factory.CreateCloudEvent()
+	if err != nil {
+		panic("could not create cloud event: " + err.Error())
+	}
+
+	m.eventSink = append(m.eventSink, ce)
+
+	return nil
+}

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -159,12 +159,17 @@ func (m *resourceClientMock) UploadDashboard(project string, stage string, servi
 }
 
 type keptnClientMock struct {
-	eventSink     []*cloudevents.Event
-	customQueries map[string]string
-	mutex         sync.Mutex
+	eventSink          []*cloudevents.Event
+	customQueries      map[string]string
+	customQueriesError error
+	mutex              sync.Mutex
 }
 
 func (m *keptnClientMock) GetCustomQueries(project string, stage string, service string) (*keptn.CustomQueries, error) {
+	if m.customQueriesError != nil {
+		return nil, m.customQueriesError
+	}
+
 	if m.customQueries == nil {
 		return keptn.NewEmptyCustomQueries(), nil
 	}

--- a/internal/sli/testdata/response_time_p95_200_0_result_warning_entity-selector.json
+++ b/internal/sli/testdata/response_time_p95_200_0_result_warning_entity-selector.json
@@ -1,0 +1,16 @@
+{
+  "totalCount": 0,
+  "nextPageKey": null,
+  "warnings": [
+    "The dimension key dt.entity.services has been referenced, but the metric has no such key"
+  ],
+  "result": [
+    {
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.services\"):percentile(95)",
+      "data": [],
+      "warnings": [
+        "The dimension key dt.entity.services has been referenced, but the metric has no such key"
+      ]
+    }
+  ]
+}

--- a/internal/sli/testdata/response_time_p95_200_0_result_wrong-tag.json
+++ b/internal/sli/testdata/response_time_p95_200_0_result_wrong-tag.json
@@ -1,0 +1,10 @@
+{
+  "totalCount": 0,
+  "nextPageKey": null,
+  "result": [
+    {
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)",
+      "data": []
+    }
+  ]
+}

--- a/internal/sli/testdata/response_time_p95_200_1_result.json
+++ b/internal/sli/testdata/response_time_p95_200_1_result.json
@@ -1,0 +1,21 @@
+{
+  "totalCount": 1,
+  "nextPageKey": null,
+  "result": [
+    {
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)",
+      "data": [
+        {
+          "dimensions": [],
+          "dimensionMap": {},
+          "timestamps": [
+            1632835320000
+          ],
+          "values": [
+            12439.619479902443
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/sli/testdata/response_time_p95_200_1_result_defaults.json
+++ b/internal/sli/testdata/response_time_p95_200_1_result_defaults.json
@@ -1,0 +1,21 @@
+{
+  "totalCount": 1,
+  "nextPageKey": null,
+  "result": [
+    {
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)",
+      "data": [
+        {
+          "dimensions": [],
+          "dimensionMap": {},
+          "timestamps": [
+            1632835320000
+          ],
+          "values": [
+            12439.619479902443
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/sli/testdata/response_time_p95_400_constraints-violated.json
+++ b/internal/sli/testdata/response_time_p95_400_constraints-violated.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "code": 400,
+    "message": "Constraints violated.",
+    "constraintViolations": [
+      {
+        "path": "nextPageKey",
+        "message": "expected one of nextPageKey or metricSelector to be specified",
+        "parameterLocation": "QUERY",
+        "location": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
this addresses #413

removes default fallback behaviors 
* if custom SLI definitions (in sli.yaml) could not be retrieved - will return an error now
* if custom SLI definitions (in sli.yaml) could not be parsed correctly due to invalid YAML - will return an error now
* if desired indicator could not be found in custom SLI definitions (in sli.yaml) e.g. due to a misspelled indicator - will return an error now


we still fallback to default SLI definitions in two cases:
* there is no `dynatrace/sli.yaml` file
* there is a `dynatrace/sli.yaml` file, but it has no `indicators` defined


adds more details to error messages:
* if no results could be retrieved by this query, then sometimes there is a `warning` returned by the Dynatrace API. This is now included in the `message`  of the `SLIResult`