### PR TITLE
Remove extra https prefix in link in dashboard creation message

### DIFF
--- a/internal/credentials/credentials_manager.go
+++ b/internal/credentials/credentials_manager.go
@@ -17,6 +17,7 @@ import (
 
 // DTCredentials is a struct for the tenant and api token information
 type DTCredentials struct {
+	// Base URL of Dynatrace tenant. This is always prefixed with "https://" or "http://"
 	Tenant   string `json:"DT_TENANT" yaml:"DT_TENANT"`
 	ApiToken string `json:"DT_API_TOKEN" yaml:"DT_API_TOKEN"`
 }

--- a/internal/dynatrace/dynatrace_client.go
+++ b/internal/dynatrace/dynatrace_client.go
@@ -149,12 +149,7 @@ func (dt *Client) sendRequest(apiPath string, method string, body []byte) ([]byt
 
 // creates http request for api call with appropriate headers including authorization
 func (dt *Client) createRequest(apiPath string, method string, body []byte) (*http.Request, error) {
-	var url string
-	if !strings.HasPrefix(dt.credentials.Tenant, "http://") && !strings.HasPrefix(dt.credentials.Tenant, "https://") {
-		url = "https://" + dt.credentials.Tenant + apiPath
-	} else {
-		url = dt.credentials.Tenant + apiPath
-	}
+	var url = dt.credentials.Tenant + apiPath
 
 	log.WithFields(log.Fields{"method": method, "url": url}).Debug("creating Dynatrace API request")
 

--- a/internal/monitoring/dashboard_creation.go
+++ b/internal/monitoring/dashboard_creation.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"fmt"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 	"github.com/keptn-contrib/dynatrace-service/internal/env"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -52,10 +53,10 @@ func (dc *DashboardCreation) Create(project string, shipyard keptnv2.Shipyard) C
 			Message: err.Error(),
 		}
 	}
-	log.WithField("dashboardUrl", "https://"+dc.client.Credentials().Tenant+"/#dashboards").Info("Dynatrace dashboard created successfully")
+	log.WithField("dashboardUrl", dc.client.Credentials().Tenant+"/#dashboards").Info("Dynatrace dashboard created successfully")
 	return ConfigResult{
 		Success: true, // I guess this should be true not false?
-		Message: "Dynatrace dashboard created successfully. You can view it here: https://" + dc.client.Credentials().Tenant + "/#dashboards",
+		Message: "Dynatrace dashboard created successfully. You can view it here: " + dc.client.Credentials().Tenant + "/#dashboards",
 	}
 }
 

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -105,7 +105,7 @@ func (mec MetricEventCreation) Create(project string, stage string, service stri
 
 	if len(metricsEventResults) > 0 {
 		// TODO: improve this?
-		log.Info("To review and enable the generated custom metric events, please go to: https://" + mec.dtClient.Credentials().Tenant + "/#settings/anomalydetection/metricevents")
+		log.Info("To review and enable the generated custom metric events, please go to: " + mec.dtClient.Credentials().Tenant + "/#settings/anomalydetection/metricevents")
 	}
 
 	return metricsEventResults


### PR DESCRIPTION
Closes #504 

This PR:
- Removes extra `https://` prefix in messages and logs
- Removes a redundant check for prefix in `dynatrace.Client`
- Documents that the `Tenant` field of `DTCredentials` should always be prefixed correctly