### PR TITLE
`GetSLIFinishedEventData.result` is now set to `fail` in case of error

### DIFF
--- a/internal/sli/get_sli_events_factory.go
+++ b/internal/sli/get_sli_events_factory.go
@@ -4,6 +4,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"strings"
 )
 
 type GetSliStartedEventFactory struct {
@@ -35,16 +36,32 @@ func (f *GetSliStartedEventFactory) CreateCloudEvent() (*cloudevents.Event, erro
 type GetSliFinishedEventFactory struct {
 	event           GetSLITriggeredAdapterInterface
 	indicatorValues []*keptnv2.SLIResult
+	err             error
 }
 
-func NewGetSLIFinishedEventFactory(event GetSLITriggeredAdapterInterface, indicatorValues []*keptnv2.SLIResult) *GetSliFinishedEventFactory {
+func NewGetSLIFinishedEventFactory(event GetSLITriggeredAdapterInterface, indicatorValues []*keptnv2.SLIResult, err error) *GetSliFinishedEventFactory {
 	return &GetSliFinishedEventFactory{
 		event:           event,
 		indicatorValues: indicatorValues,
+		err:             err,
 	}
 }
 
 func (f *GetSliFinishedEventFactory) CreateCloudEvent() (*cloudevents.Event, error) {
+	result := keptnv2.ResultPass
+	message := ""
+	if f.err != nil {
+		result = keptnv2.ResultFailed
+		message = f.err.Error()
+	}
+
+	// get error messages if only some SLIs failed and there was no error
+	sliErrorMessages := getErrorMessagesFromSLIResults(f.indicatorValues)
+	if f.err == nil && len(sliErrorMessages) > 0 {
+		result = keptnv2.ResultFailed
+		message = strings.Join(sliErrorMessages, "; ")
+	}
+
 	getSLIFinishedEvent := keptnv2.GetSLIFinishedEventData{
 		EventData: keptnv2.EventData{
 			Project: f.event.GetProject(),
@@ -52,7 +69,8 @@ func (f *GetSliFinishedEventFactory) CreateCloudEvent() (*cloudevents.Event, err
 			Service: f.event.GetService(),
 			Labels:  f.event.GetLabels(),
 			Status:  keptnv2.StatusSucceeded,
-			Result:  keptnv2.ResultPass,
+			Result:  result,
+			Message: message,
 		},
 		GetSLI: keptnv2.GetSLIFinished{
 			IndicatorValues: f.indicatorValues,
@@ -62,4 +80,14 @@ func (f *GetSliFinishedEventFactory) CreateCloudEvent() (*cloudevents.Event, err
 	}
 
 	return adapter.NewCloudEventFactory(f.event, keptnv2.GetFinishedEventType(keptnv2.GetSLITaskName), getSLIFinishedEvent).CreateCloudEvent()
+}
+func getErrorMessagesFromSLIResults(indicatorValues []*keptnv2.SLIResult) []string {
+	var errorMessages []string
+	for _, indicator := range indicatorValues {
+		if indicator.Success == false {
+			errorMessages = append(errorMessages, indicator.Message)
+		}
+	}
+
+	return errorMessages
 }

--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -403,7 +403,7 @@ func (eh *GetSLIEventHandler) sendGetSLIFinishedEvent(indicatorValues []*keptnv2
 	// if an error was set - the indicators will be set to failed and error message is set to each
 	indicatorValues = resetIndicatorsInCaseOfError(err, eh.event, indicatorValues)
 
-	return eh.sendEvent(NewGetSLIFinishedEventFactory(eh.event, indicatorValues))
+	return eh.sendEvent(NewGetSLIFinishedEventFactory(eh.event, indicatorValues, err))
 }
 
 func resetIndicatorsInCaseOfError(err error, eventData GetSLITriggeredAdapterInterface, indicatorValues []*keptnv2.SLIResult) []*keptnv2.SLIResult {


### PR DESCRIPTION
also the error message is added to `GetSLIFinishedEventData.message`

this closes #507