### PR TITLE
Patch/cherry pick from feature deploy to keptn demo

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: latest
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.dynatraceService.image.repository}}
         - name: dynatrace-service
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -90,6 +91,7 @@ spec:
               port: 10999
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{ end }}
         - name: distributor
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z0-9][a-z0-9-./]{2,511}$"
+              "pattern": "^$|^[a-z0-9][a-z0-9-./]{0,511}$"
             },
             "pullPolicy": {
               "enum": [


### PR DESCRIPTION
This PR cherry picks two commits from the work to deploy the dynatrace-service with Keptn:
- First commit fixes the chart versions so our CI workflows, specifically so `gh-actions-scripts/build_helm_chart.sh` will correctly replace the versions
- Second commit makes it possible to omit the dynatrace-service container when deploying via Helm, useful for the local debugging workflow.