### PR TITLE
Remove deprecated fields from MetricsQueryResult

### DIFF
--- a/internal/dynatrace/metrics_client.go
+++ b/internal/dynatrace/metrics_client.go
@@ -35,9 +35,7 @@ type DimensionDefinition struct {
 
 // MetricsQueryResult is struct for /metrics/query
 type MetricsQueryResult struct {
-	TotalCount  int                       `json:"totalCount"`
-	NextPageKey string                    `json:"nextPageKey"`
-	Result      []MetricQueryResultValues `json:"result"`
+	Result []MetricQueryResultValues `json:"result"`
 }
 
 type MetricQueryResultValues struct {


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>