### PR TITLE
Update `create_release_draft.yaml` workflow for breaking changes in github-script v5

### DIFF
--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -161,7 +161,7 @@ jobs:
             console.log(`Trying to fetch release by tag '${tag}'...`);
 
             try {
-              release = await github.repos.getReleaseByTag({
+              release = await github.rest.repos.getReleaseByTag({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag: tag
@@ -180,13 +180,13 @@ jobs:
         uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
+          script: |            
             let tag = "${{ env.VERSION }}";
             console.log(`Trying to fetch DRAFT release by tag '${tag}'...`);
 
             try {
               // get all releases (including drafts)
-              let releases = await github.repos.listReleases({
+              let releases = await github.rest.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo
               });


### PR DESCRIPTION
Based on the [breaking changes listed for v5 of github-script](https://github.com/actions/github-script#breaking-changes-in-v5), I updated our script. Based on my testing this fixes the issue with our create release draft workflow failing.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>