### PR TITLE
Easily support multiple SLI results in get SLI triggered event tests

### DIFF
--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
@@ -92,7 +92,7 @@ func TestErrorIsReturnedWhenSLISLOOrDashboardFileWritingFails(t *testing.T) {
 	}
 
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExact(dynatrace.DashboardsPath+"/12345678-1111-4444-8888-123456789012", "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli.json")
+	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli.json")
 	handler.AddExact(dynatrace.MetricsPath+"/builtin:service.response.time", "./testdata/sli_via_dashboard_test/metric_definition_service-response-time.json")
 	handler.AddExact(
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895.000000%29%3Anames&resolution=Inf&to=1632835299000",
@@ -130,7 +130,7 @@ func TestThatThereIsNoFallbackToSLIsFromDashboard(t *testing.T) {
 
 	// we need metrics definition, because we will be retrieving metrics from dashboard
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExact(dynatrace.DashboardsPath+"/12345678-1111-4444-8888-123456789012", "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli_parse_only_on_change.json")
+	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli_parse_only_on_change.json")
 	handler.AddExact(dynatrace.MetricsPath+"/builtin:service.response.time", "./testdata/sli_via_dashboard_test/metric_definition_service-response-time.json")
 	handler.AddExact(
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895.000000%29%3Anames&resolution=Inf&to=1632835299000",
@@ -183,7 +183,7 @@ func (m *uploadWillFailResourceClientMock) UploadSLOs(project string, stage stri
 //   * therefore SLI and SLO should be empty and an upload of either SLO or SLI should fail the test
 func TestEmptySLOAndSLIAreNotWritten(t *testing.T) {
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExact(dynatrace.DashboardsPath+"/12345678-1111-4444-8888-123456789012", "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli.json")
+	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, "./testdata/sli_via_dashboard_test/dashboard_custom_charting_single_sli.json")
 	handler.AddExact(dynatrace.MetricsPath+"/builtin:service.response.time", "./testdata/sli_via_dashboard_test/metric_definition_service-response-time.json")
 	handler.AddExact(
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895.000000%29%3Anames&resolution=Inf&to=1632835299000",
@@ -212,7 +212,7 @@ func TestThatFallbackToSLIsFromDashboardIfDashboardDidNotChangeWorks(t *testing.
 
 	// we do not need metrics definition and metrics query, because we will should not be looking into the tile
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExact(dynatrace.DashboardsPath+"/12345678-1111-4444-8888-123456789012", "./testdata/sli_via_dashboard_test/dashboard_custom_charting_without_matching_tile_name.json")
+	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, "./testdata/sli_via_dashboard_test/dashboard_custom_charting_without_matching_tile_name.json")
 
 	// we do not need custom queries, as we are using the dashboard
 	kClient := &keptnClientMock{}
@@ -229,7 +229,7 @@ func TestThatFallbackToSLIsFromDashboardIfDashboardDidNotChangeWorks(t *testing.
 }
 
 func assertThatDashboardTestIsCorrect(t *testing.T, handler http.Handler, kClient *keptnClientMock, rClient keptn.ResourceClientInterface, eventAssertionsFunc func(data *keptnv2.GetSLIFinishedEventData), sliResultAssertionsFuncs ...func(t *testing.T, actual *keptnv2.SLIResult)) {
-	setupTestAndAssertNoError(t, handler, kClient, rClient, "12345678-1111-4444-8888-123456789012")
+	setupTestAndAssertNoError(t, handler, kClient, rClient, testDashboardID)
 
 	assertThatEventHasExpectedPayloadWithMatchingFunc(t, kClient.eventSink, eventAssertionsFunc, sliResultAssertionsFuncs...)
 }

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
@@ -29,14 +29,14 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
 		assert.Contains(t, actual.Message, "response_time_p95")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -59,7 +59,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
@@ -67,7 +67,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 		assert.Contains(t, actual.Message, "400")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -84,14 +84,14 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreInvalidYAML(t *testing.T) {
 		customQueriesError: fmt.Errorf(errorMessage),
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
 		assert.Contains(t, actual.Message, errorMessage)
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -114,7 +114,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsA
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
@@ -122,7 +122,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsA
 		assert.Contains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -145,7 +145,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
@@ -153,7 +153,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(
 		assert.NotContains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -176,7 +176,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsMultipleRe
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
@@ -184,7 +184,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsMultipleRe
 		assert.NotContains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -234,7 +234,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsUsingWrongMetri
 				},
 			}
 
-			assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
+			sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 				assert.EqualValues(t, indicator, actual.Metric)
 				assert.EqualValues(t, 0, actual.Value)
 				assert.EqualValues(t, false, actual.Success)
@@ -242,7 +242,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsUsingWrongMetri
 				assert.Contains(t, actual.Message, "SLI definition format")
 			}
 
-			assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, true)
+			assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)
 		})
 	}
 }
@@ -265,13 +265,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreDefinedButEmpty(t *testing.T) {
 	// TODO 2021-09-29: we should be able to differentiate between 'not there' and 'no SLIs defined' - the latter could be intentional
 	kClient := &keptnClientMock{}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
-		assert.EqualValues(t, indicator, actual.Metric)
-		assert.EqualValues(t, 12.439619479902443, actual.Value) // div by 1000 from dynatrace API result!
-		assert.EqualValues(t, true, actual.Success)
-	}
-
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, false)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, false, createSLIResultAssertionsFunc(indicator, 12.439619479902443, true))
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -290,16 +284,10 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 		},
 	}
 
-	assertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
-		assert.EqualValues(t, indicator, actual.Metric)
-		assert.EqualValues(t, 12.439619479902443, actual.Value) // div by 1000 from dynatrace API result!
-		assert.EqualValues(t, true, actual.Success)
-	}
-
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, assertionsFunc, false)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, false, createSLIResultAssertionsFunc(indicator, 12.439619479902443, true))
 }
 
-func assertThatCustomSLITestIsCorrect(t *testing.T, handler http.Handler, kClient *keptnClientMock, assertionsFunc func(t *testing.T, actual *keptnv2.SLIResult), shouldFail bool) {
+func assertThatCustomSLITestIsCorrect(t *testing.T, handler http.Handler, kClient *keptnClientMock, shouldFail bool, sliResultAssertionsFunc func(t *testing.T, actual *keptnv2.SLIResult)) {
 	// we use the special mock for the resource client
 	// we do not want to query a dashboard, so we leave it empty
 	setupTestAndAssertNoError(t, handler, kClient, &resourceClientMock{t: t}, "")
@@ -314,5 +302,5 @@ func assertThatCustomSLITestIsCorrect(t *testing.T, handler http.Handler, kClien
 		}
 	}
 
-	assertThatEventHasExpectedPayloadWithMatchingFunc(t, assertionsFunc, kClient.eventSink, eventAssertionsFunc)
+	assertThatEventHasExpectedPayloadWithMatchingFunc(t, kClient.eventSink, eventAssertionsFunc, sliResultAssertionsFunc)
 }

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -20,6 +20,7 @@ import (
 
 const indicator = "response_time_p95"
 const testDynatraceAPIToken = "dtOc01.ST2EY72KQINMH574WMNVI7YN.G3DFPBEJYMODIDAEX454M7YWBUVEFOWKPRVMWFASS64NFH52PX6BNDVFFM572RZM"
+const testDashboardID = "12345678-1111-4444-8888-123456789012"
 
 func setupTestAndAssertNoError(t *testing.T, handler http.Handler, kClient *keptnClientMock, rClient keptn.ResourceClientInterface, dashboard string) {
 	ev := &getSLIEventData{


### PR DESCRIPTION
This PR updates some helper methods to make it even easier to write tests around get SLI triggered events. Tests using these methods were then also updated.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>