### PR TITLE
Improve parsing and validation of sli def

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -16,8 +16,6 @@ import (
 	"github.com/keptn/go-utils/pkg/lib/keptn"
 )
 
-// This is the label name for the Problem URL label
-const PROBLEMURL_LABEL = "Problem URL"
 const KEPTNSBRIDGE_LABEL = "Keptns Bridge"
 
 const shipyardController = "SHIPYARD_CONTROLLER"

--- a/internal/problem/problem_events_factory.go
+++ b/internal/problem/problem_events_factory.go
@@ -2,11 +2,13 @@ package problem
 
 import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
-	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	keptn "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 )
+
+const problemURLLabel = "Problem URL"
 
 type ProblemClosedEventFactory struct {
 	event ProblemAdapterInterface
@@ -36,7 +38,7 @@ func (f *ProblemClosedEventFactory) CreateCloudEvent() (*cloudevents.Event, erro
 	// https://github.com/keptn-contrib/dynatrace-service/issues/176
 	// add problem URL as label so it becomes clickable
 	problemData.Labels = make(map[string]string)
-	problemData.Labels[common.PROBLEMURL_LABEL] = f.event.GetProblemURL()
+	problemData.Labels[problemURLLabel] = f.event.GetProblemURL()
 
 	return adapter.NewCloudEventFactoryBase(f.event, keptn.ProblemEventType, problemData).CreateCloudEvent()
 
@@ -78,7 +80,7 @@ func (f *RemediationTriggeredEventFactory) CreateCloudEvent() (*cloudevents.Even
 	// https://github.com/keptn-contrib/dynatrace-service/issues/176
 	// add problem URL as label so it becomes clickable
 	remediationEventData.Labels = make(map[string]string)
-	remediationEventData.Labels[common.PROBLEMURL_LABEL] = f.event.GetProblemURL()
+	remediationEventData.Labels[problemURLLabel] = f.event.GetProblemURL()
 
 	eventType := keptnv2.GetTriggeredEventType(f.event.GetStage() + "." + remediationTaskName)
 

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
@@ -47,10 +47,6 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *testing.T) {
 	// error here: metric(s)Selector=
 	handler := test.NewFileBasedURLHandler(t)
-	handler.AddExactError(
-		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricsSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
-		400,
-		"./testdata/response_time_p95_400_constraints-violated.json")
 
 	// error here as well: metric(s)Selector=
 	kClient := &keptnClientMock{

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
@@ -63,8 +63,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 		assert.EqualValues(t, indicator, actual.Metric)
 		assert.EqualValues(t, 0, actual.Value)
 		assert.EqualValues(t, false, actual.Success)
-		assert.Contains(t, actual.Message, "metricSelector to be specified")
-		assert.Contains(t, actual.Message, "400")
+		assert.Contains(t, actual.Message, "could not parse metrics query")
 	}
 
 	assertThatCustomSLITestIsCorrect(t, handler, kClient, true, sliResultAssertionsFunc)

--- a/internal/sli/metrics/legacy_query_transformation.go
+++ b/internal/sli/metrics/legacy_query_transformation.go
@@ -1,0 +1,103 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// url to the metrics api format migration document
+const metricsAPIOldFormatNewFormatDoc = "https://github.com/keptn-contrib/dynatrace-sli-service/blob/master/docs/CustomQueryFormatMigration.md"
+
+const (
+	scopeKeyPrefix = "scope="
+	v1Delimiter    = "?"
+	serviceType    = "type(SERVICE)"
+)
+
+// LegacyQueryTransformation will parse a un-encoded metric definition query string (usually found in sli.yaml files)
+type LegacyQueryTransformation struct {
+	query string
+}
+
+func NewLegacyQueryTransformation(query string) *LegacyQueryTransformation {
+	return &LegacyQueryTransformation{
+		query: query,
+	}
+}
+
+// Transform will try to transform a un-encoded metric definition query string (usually found in sli.yaml files) into a
+// valid metrics V2 API query string or return an error in case it could not successfully do that.
+// It will return the input query in case it 'assumes' the query is in metrics V2 format.
+func (p *LegacyQueryTransformation) Transform() (string, error) {
+	query := removeQuestionMark(p.query)
+
+	return transformToMetricsV2QueryFormat(query)
+}
+
+func transformToMetricsV2QueryFormat(query string) (string, error) {
+	if query == "" {
+		return "", fmt.Errorf("empty metric selector")
+	}
+
+	// support the old format with "<metric_selector>:<some_filters()>?scope=<scope>" as well as the new format with
+	// "metricSelector=<metric_selector>&entitySelector=<entity_selector>"
+	// split query string by first occurrence of "?"
+	querySplit := strings.Split(query, v1Delimiter)
+
+	// new V2 format -> everything within the query string are query parameters
+	if len(querySplit) == 1 {
+		return query, nil
+	}
+
+	log.WithFields(
+		log.Fields{
+			"query":        query,
+			"helpDocument": metricsAPIOldFormatNewFormatDoc,
+		}).Warn("COMPATIBILITY WARNING: query uses the old format")
+
+	entitySelectorValue, err := transformScopeToEntitySelector(querySplit[1])
+	if err != nil {
+		return "", err
+	}
+
+	// build the new query format: old format with "?" - everything left of the ? is the identifier, everything right are query params
+	return fmt.Sprintf("%s=%s&%s=%s", metricSelectorKey, querySplit[0], entitySelectorKey, entitySelectorValue), nil
+}
+
+func transformScopeToEntitySelector(scope string) (string, error) {
+	if !strings.HasPrefix(scope, scopeKeyPrefix) {
+		return "", fmt.Errorf("invalid metric query - missing 'scope=<scope>' part")
+	}
+
+	// compatibility with old scope=... custom queries
+	scopeValue := strings.TrimPrefix(scope, scopeKeyPrefix)
+	if scopeValue == "" {
+		return "", fmt.Errorf("invalid metric query - missing value for 'scope=' key")
+	}
+
+	if scopeValue != "" {
+		log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: querying the new metrics API requires use of entitySelector rather than scope")
+		// scope is no longer supported in the new API, it needs to be called "entitySelector" and contain type(SERVICE)
+		if !strings.Contains(scopeValue, serviceType) {
+			log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: Automatically adding type(SERVICE) to entitySelector for compatibility with the new Metrics API")
+			scopeValue += "," + serviceType
+		}
+	}
+
+	return scopeValue, nil
+}
+
+func removeQuestionMark(query string) string {
+	if strings.HasPrefix(query, v1Delimiter) {
+		log.WithFields(
+			log.Fields{
+				"query":        query,
+				"helpDocument": metricsAPIOldFormatNewFormatDoc,
+			}).Warn("COMPATIBILITY WARNING: query string is not compatible. Auto-removing the ? in front.")
+		return strings.Replace(query, v1Delimiter, "", 1)
+	}
+
+	return query
+}

--- a/internal/sli/metrics/legacy_query_transformation.go
+++ b/internal/sli/metrics/legacy_query_transformation.go
@@ -57,13 +57,13 @@ func transformToMetricsV2QueryFormat(query string) (string, error) {
 			"helpDocument": metricsAPIOldFormatNewFormatDoc,
 		}).Warn("COMPATIBILITY WARNING: query uses the old format")
 
-	entitySelectorValue, err := transformScopeToEntitySelector(querySplit[1])
+	entitySelector, err := transformScopeToEntitySelector(querySplit[1])
 	if err != nil {
 		return "", err
 	}
 
 	// build the new query format: old format with "?" - everything left of the ? is the identifier, everything right are query params
-	return fmt.Sprintf("%s=%s&%s=%s", metricSelectorKey, querySplit[0], entitySelectorKey, entitySelectorValue), nil
+	return fmt.Sprintf("%s=%s&%s", metricSelectorKey, querySplit[0], entitySelector), nil
 }
 
 func transformScopeToEntitySelector(scope string) (string, error) {
@@ -77,16 +77,14 @@ func transformScopeToEntitySelector(scope string) (string, error) {
 		return "", fmt.Errorf("invalid metric query - missing value for 'scope=' key")
 	}
 
-	if scopeValue != "" {
-		log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: querying the new metrics API requires use of entitySelector rather than scope")
-		// scope is no longer supported in the new API, it needs to be called "entitySelector" and contain type(SERVICE)
-		if !strings.Contains(scopeValue, serviceType) {
-			log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: Automatically adding type(SERVICE) to entitySelector for compatibility with the new Metrics API")
-			scopeValue += "," + serviceType
-		}
+	log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: querying the new metrics API requires use of entitySelector rather than scope")
+	// scope is no longer supported in the new API, it needs to be called "entitySelector" and contain type(SERVICE)
+	if !strings.Contains(scopeValue, serviceType) {
+		log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: Automatically adding type(SERVICE) to entitySelector for compatibility with the new Metrics API")
+		scopeValue += "," + serviceType
 	}
 
-	return scopeValue, nil
+	return fmt.Sprintf("%s=%s", entitySelectorKey, scopeValue), nil
 }
 
 func removeQuestionMark(query string) string {

--- a/internal/sli/metrics/legacy_query_transformation_test.go
+++ b/internal/sli/metrics/legacy_query_transformation_test.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformationFromOldFormatToNewFormatWorks(t *testing.T) {
+	testConfigs := []struct {
+		name           string
+		input          string
+		expectedResult string
+		shouldFail     bool
+		errMessage     string
+	}{
+		{
+			name:           "old standard format transformed to new one",
+			input:          "builtin:service.requestCount.total:merge(0):sum?scope=tag(keptn_project:my-proj),tag(keptn_stage:dev),tag(keptn_service:carts),tag(keptn_deployment:direct)",
+			expectedResult: "metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=tag(keptn_project:my-proj),tag(keptn_stage:dev),tag(keptn_service:carts),tag(keptn_deployment:direct),type(SERVICE)",
+		},
+		{
+			name:           "old standard format without scope - no changes to input",
+			input:          "builtin:service.requestCount.total:merge(0):sum",
+			expectedResult: "builtin:service.requestCount.total:merge(0):sum",
+		},
+		{
+			name:       "old standard format, missing scope key",
+			input:      "builtin:service.requestCount.total:merge(0):sum?",
+			shouldFail: true,
+			errMessage: "missing 'scope=<scope>'",
+		},
+		{
+			name:       "old standard format, missing scope value",
+			input:      "builtin:service.requestCount.total:merge(0):sum?scope",
+			shouldFail: true,
+			errMessage: "missing 'scope=<scope>'",
+		},
+		{
+			name:       "old standard format, missing scope value",
+			input:      "builtin:service.requestCount.total:merge(0):sum?scope=",
+			shouldFail: true,
+			errMessage: "missing value",
+		},
+	}
+	for _, testConfig := range testConfigs {
+		tc := testConfig
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := NewLegacyQueryTransformation(tc.input).Transform()
+			if tc.shouldFail {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMessage)
+				assert.Empty(t, actual)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, actual)
+				assert.Empty(t, tc.errMessage, "fix test setup")
+			}
+		})
+	}
+}

--- a/internal/sli/metrics/metrics_query_builder.go
+++ b/internal/sli/metrics/metrics_query_builder.go
@@ -2,17 +2,13 @@ package metrics
 
 import (
 	"fmt"
+	"time"
+
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
-	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
-	log "github.com/sirupsen/logrus"
-	"net/url"
-	"strings"
-	"time"
 )
-
-// store url to the metrics api format migration document
-const metricsAPIOldFormatNewFormatDoc = "https://github.com/keptn-contrib/dynatrace-sli-service/blob/master/docs/CustomQueryFormatMigration.md"
 
 type QueryBuilder struct {
 	eventData     adapter.EventContentAdapter
@@ -36,66 +32,29 @@ func (b *QueryBuilder) Build(metricQuery string, startUnix time.Time, endUnix ti
 	// replace query params (e.g., $PROJECT, $STAGE, $SERVICE ...)
 	metricQuery = common.ReplaceQueryParameters(metricQuery, b.customFilters, b.eventData)
 
-	if strings.HasPrefix(metricQuery, "?metricSelector=") {
-		log.WithFields(
-			log.Fields{
-				"query":        metricQuery,
-				"helpDocument": metricsAPIOldFormatNewFormatDoc,
-			}).Debug("COMPATIBILITY WARNING: query string is not compatible. Auto-removing the ? in front.")
-		metricQuery = strings.Replace(metricQuery, "?metricSelector=", "metricSelector=", 1)
-	}
+	// try to do the legacy query transformation
+	metricQuery, err := NewLegacyQueryTransformation(metricQuery).Transform()
 
-	// split query string by first occurrence of "?"
-	querySplit := strings.Split(metricQuery, "?")
-	metricSelector := ""
-	metricQueryParams := ""
-
-	// support the old format with "metricSelector:someFilters()?scope=..." as well as the new format with
-	// "?metricSelector=metricSelector&entitySelector=...&scope=..."
-	if len(querySplit) == 1 {
-		// new format without "?" -> everything within the query string are query parameters
-		metricQueryParams = querySplit[0]
-	} else {
-		log.WithFields(
-			log.Fields{
-				"query":        metricQueryParams,
-				"helpDocument": metricsAPIOldFormatNewFormatDoc,
-			}).Debug("COMPATIBILITY WARNING: query uses the old format")
-		// old format with "?" - everything left of the ? is the identifier, everything right are query params
-		metricSelector = querySplit[0]
-
-		// build the new query
-		metricQueryParams = fmt.Sprintf("metricSelector=%s&%s", querySplit[0], querySplit[1])
-	}
-
-	q, err := url.ParseQuery(metricQueryParams)
+	q, err := NewQueryParsing(metricQuery).Parse()
 	if err != nil {
-		return "", "", fmt.Errorf("could not parse metrics URL: %s", err.Error())
+		return "", "", fmt.Errorf("could not parse metrics query: %s", err.Error())
 	}
 
-	q.Add("resolution", "Inf") // resolution=Inf means that we only get 1 datapoint (per service)
-	q.Add("from", common.TimestampToString(startUnix))
-	q.Add("to", common.TimestampToString(endUnix))
-
-	// check if q contains "scope"
-	scopeData := q.Get("scope")
-
-	// compatibility with old scope=... custom queries
-	if scopeData != "" {
-		log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: querying the new metrics API requires use of entitySelector rather than scope")
-		// scope is no longer supported in the new API, it needs to be called "entitySelector" and contain type(SERVICE)
-		if !strings.Contains(scopeData, "type(SERVICE)") {
-			log.WithField("helpDocument", metricsAPIOldFormatNewFormatDoc).Debug("COMPATIBILITY WARNING: Automatically adding type(SERVICE) to entitySelector for compatibility with the new Metrics API")
-			scopeData = fmt.Sprintf("%s,type(SERVICE)", scopeData)
-		}
-		// add scope as entitySelector
-		q.Add("entitySelector", scopeData)
+	// resolution=Inf means that we only get 1 datapoint (per service)
+	err = q.Add(resolutionKey, "Inf")
+	if err != nil {
+		return "", "", err
 	}
 
-	// check metricSelector
-	if metricSelector == "" {
-		metricSelector = q.Get("metricSelector")
+	err = q.Add(fromKey, common.TimestampToString(startUnix))
+	if err != nil {
+		return "", "", err
 	}
 
-	return q.Encode(), metricSelector, nil
+	err = q.Add(toKey, common.TimestampToString(endUnix))
+	if err != nil {
+		return "", "", err
+	}
+
+	return q.Encode(), q.GetMetricSelector(), nil
 }

--- a/internal/sli/metrics/metrics_query_builder.go
+++ b/internal/sli/metrics/metrics_query_builder.go
@@ -34,10 +34,13 @@ func (b *QueryBuilder) Build(metricQuery string, startUnix time.Time, endUnix ti
 
 	// try to do the legacy query transformation
 	metricQuery, err := NewLegacyQueryTransformation(metricQuery).Transform()
+	if err != nil {
+		return "", "", fmt.Errorf("could not parse old format metrics query: %v, %w", metricQuery, err)
+	}
 
 	q, err := NewQueryParsing(metricQuery).Parse()
 	if err != nil {
-		return "", "", fmt.Errorf("could not parse metrics query: %s", err.Error())
+		return "", "", fmt.Errorf("could not parse metrics query: %v, %w", metricQuery, err)
 	}
 
 	// resolution=Inf means that we only get 1 datapoint (per service)

--- a/internal/sli/metrics/metrics_query_builder_test.go
+++ b/internal/sli/metrics/metrics_query_builder_test.go
@@ -60,6 +60,14 @@ func TestBuildingMetricQueryWorks(t *testing.T) {
 			errMessage: "could not parse metrics query",
 		},
 		{
+			// actually this is a short coming in the current SLI format design - Dynatrace API would not complain
+			name:       "event context data cannot be correctly encoded because of '?' and fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(my-tag:why?)",
+			shouldFail: true,
+			// legacy query transformation assumes that this is an old query because of the '?' inside
+			errMessage: "could not parse old format",
+		},
+		{
 			name:       "misspelled metricSelector key fails",
 			input:      "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE)",
 			shouldFail: true,

--- a/internal/sli/metrics/metrics_query_builder_test.go
+++ b/internal/sli/metrics/metrics_query_builder_test.go
@@ -1,0 +1,92 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/test"
+)
+
+func TestBuildingMetricQueryWorks(t *testing.T) {
+
+	ev := &test.EventData{
+		Project: "my-project",
+		Stage:   "my-stage",
+		Service: "my-service",
+		Labels: map[string]string{
+			"good-label1": "tom and jerry",
+			"good-label2": "tom + jerry/gerry",
+			"bad-label1":  "tom & jerry",
+		},
+	}
+	startTime := time.Unix(1636000000, 0)
+	endTime := time.Unix(1636000120, 0)
+
+	testConfigs := []struct {
+		name                   string
+		input                  string
+		expectedMetricQuery    string
+		expectedMetricSelector string
+		sliFilter              []*keptnv2.SLIFilter
+		shouldFail             bool
+		errMessage             string
+	}{
+		{
+			name:                   "simple old format transformed to new one",
+			input:                  "builtin:service.requestCount.total:merge(0):sum?scope=tag(keptn_project:my-proj),tag(keptn_stage:dev),tag(keptn_service:carts),tag(keptn_deployment:direct)",
+			expectedMetricQuery:    "entitySelector=tag%28keptn_project%3Amy-proj%29%2Ctag%28keptn_stage%3Adev%29%2Ctag%28keptn_service%3Acarts%29%2Ctag%28keptn_deployment%3Adirect%29%2Ctype%28SERVICE%29&from=1636000000000&metricSelector=builtin%3Aservice.requestCount.total%3Amerge%280%29%3Asum&resolution=Inf&to=1636000120000",
+			expectedMetricSelector: "builtin:service.requestCount.total:merge(0):sum",
+		},
+		{
+			name:                   "event context data is correctly encoded in metric V2 query",
+			input:                  "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag($LABEL.good-label1),tag($LABEL.good-label2)",
+			expectedMetricQuery:    "entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Amy-project%29%2Ctag%28keptn_stage%3Amy-stage%29%2Ctag%28keptn_service%3Amy-service%29%2Ctag%28tom+and+jerry%29%2Ctag%28tom+%2B+jerry%2Fgerry%29&from=1636000000000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1636000120000",
+			expectedMetricSelector: "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)",
+		},
+		{
+			name:                   "uri reserved characters are encoded correctly",
+			input:                  "metricSelector=(calc:service.$rt_csm:filter(and(eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\"),in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")))):splitBy():avg:auto:sort(value(avg,descending)))/((calc:service.$reqcnt_csm:filter(and(in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")),eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\")))):splitBy():sum:auto:sort(value(sum,descending))/(1))",
+			expectedMetricQuery:    "from=1636000000000&metricSelector=%28calc%3Aservice.%24rt_csm%3Afilter%28and%28eq%28Dimension%2C%22request+Actions.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave_Rest_customer-profile.%22%29%2Cin%28%22dt.entity.service%22%2CentitySelector%28%22type%28service%29%2CrequestAttribute%28~%22%24svc_id~%22%29%22%29%29%29%29%3AsplitBy%28%29%3Aavg%3Aauto%3Asort%28value%28avg%2Cdescending%29%29%29%2F%28%28calc%3Aservice.%24reqcnt_csm%3Afilter%28and%28in%28%22dt.entity.service%22%2CentitySelector%28%22type%28service%29%2CrequestAttribute%28~%22%24svc_id~%22%29%22%29%29%2Ceq%28Dimension%2C%22request+Actions.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave_Rest_customer-profile.%22%29%29%29%29%3AsplitBy%28%29%3Asum%3Aauto%3Asort%28value%28sum%2Cdescending%29%29%2F%281%29%29&resolution=Inf&to=1636000120000",
+			expectedMetricSelector: "(calc:service.$rt_csm:filter(and(eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\"),in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")))):splitBy():avg:auto:sort(value(avg,descending)))/((calc:service.$reqcnt_csm:filter(and(in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")),eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\")))):splitBy():sum:auto:sort(value(sum,descending))/(1))",
+		},
+		{
+			// actually this is a short coming in the current SLI format design - Dynatrace API would not complain
+			name:       "event context data cannot be correctly encoded because of '&' and fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag($LABEL.bad-label1)",
+			shouldFail: true,
+			errMessage: "could not parse metrics query",
+		},
+		{
+			name:       "misspelled metricSelector key fails",
+			input:      "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE)",
+			shouldFail: true,
+			errMessage: "unknown key",
+		},
+		{
+			name:       "duplicate entitySelector key fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE)&entitySelector=type(SERVICE)",
+			shouldFail: true,
+			errMessage: "duplicate key",
+		},
+	}
+	for _, testConfig := range testConfigs {
+		tc := testConfig
+		t.Run(tc.name, func(t *testing.T) {
+			actualMetricQuery, actualMetricSelector, err := NewQueryBuilder(ev, tc.sliFilter).Build(tc.input, startTime, endTime)
+			if tc.shouldFail {
+				assert.Error(t, err)
+				assert.Empty(t, actualMetricQuery)
+				assert.Empty(t, actualMetricSelector)
+				assert.Contains(t, err.Error(), tc.errMessage)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedMetricQuery, actualMetricQuery)
+				assert.Equal(t, tc.expectedMetricSelector, actualMetricSelector)
+				assert.Empty(t, tc.errMessage, "fix test setup")
+			}
+		})
+	}
+}

--- a/internal/sli/metrics/query_parsing.go
+++ b/internal/sli/metrics/query_parsing.go
@@ -21,9 +21,9 @@ func NewQueryParameters() *QueryParameters {
 // Add will add a key/value pair to the QueryParameters if there was no entry for the key
 // It will return an error if the key already exists
 func (p *QueryParameters) Add(key string, value string) error {
-	v, exists := p.values[key]
+	_, exists := p.values[key]
 	if exists {
-		return fmt.Errorf("duplicate query parameter '%s'", v)
+		return fmt.Errorf("duplicate key '%s'", key)
 	}
 
 	p.values[key] = value

--- a/internal/sli/metrics/query_parsing.go
+++ b/internal/sli/metrics/query_parsing.go
@@ -34,6 +34,16 @@ func (p *QueryParameters) Get(key string) string {
 	return p.values[key]
 }
 
+func (p *QueryParameters) get(key string) (string, bool) {
+	value, exists := p.values[key]
+	return value, exists
+}
+
+func (p *QueryParameters) GetMetricSelector() string {
+	value, _ := p.get(metricSelectorKey)
+	return value
+}
+
 // ForEach will iterate the QueryParameters in insertion order
 func (p *QueryParameters) ForEach(consumerFunc func(key string, value string)) {
 	for _, key := range p.getSortedKeys() {

--- a/internal/sli/metrics/query_parsing.go
+++ b/internal/sli/metrics/query_parsing.go
@@ -1,0 +1,130 @@
+package metrics
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// QueryParameters store not URL encoded key/value pairs
+type QueryParameters struct {
+	values         map[string]string
+	iterationOrder []string
+}
+
+func NewQueryParameters() *QueryParameters {
+	return &QueryParameters{
+		values:         map[string]string{},
+		iterationOrder: []string{},
+	}
+}
+
+// Add will add a key/value pair to the QueryParameters if there was no entry for the key
+// It will return an error if the key already exists
+func (p *QueryParameters) Add(key string, value string) error {
+	v, exists := p.values[key]
+	if exists {
+		return fmt.Errorf("duplicate query parameter '%s'", v)
+	}
+
+	p.values[key] = value
+	p.iterationOrder = append(p.iterationOrder, key)
+	return nil
+}
+
+func (p *QueryParameters) Get(key string) (string, bool) {
+	value, exists := p.values[key]
+	return value, exists
+}
+
+// ForEach will iterate the QueryParameters in insertion order
+func (p *QueryParameters) ForEach(consumerFunc func(key string, value string)) {
+	for _, key := range p.iterationOrder {
+		consumerFunc(key, p.values[key])
+	}
+}
+
+// Encode will encode the query parameters and return a correctly encoded URL query string
+func (p *QueryParameters) Encode() string {
+	queryString := ""
+	for _, key := range p.iterationOrder {
+		if queryString != "" {
+			queryString += "&"
+		}
+		queryString += key + "=" + url.QueryEscape(p.values[key])
+	}
+
+	return queryString
+}
+
+const (
+	fromKey           = "from"
+	toKey             = "to"
+	metricSelectorKey = "metricSelector"
+	resolutionKey     = "resolution"
+	entitySelectorKey = "entitySelector"
+	delimiter         = "&"
+	keyValueDelimiter = "="
+)
+
+// QueryParsing will parse a un-encoded metric definition query string (usually found in sli.yaml files) into QueryParameters
+type QueryParsing struct {
+	query string
+}
+
+func NewQueryParsing(query string) *QueryParsing {
+	return &QueryParsing{
+		query: strings.TrimSpace(query),
+	}
+}
+
+// Parse will try parse a un-encoded metric definition query string (usually found in sli.yaml files) into QueryParameters
+// or return an error in case it could not successfully do that.
+// It will only support the current Metrics API V2 format (without a '?' prefix)
+func (p *QueryParsing) Parse() (*QueryParameters, error) {
+	if p.query == "" {
+		return nil, fmt.Errorf("empty metric definition")
+	}
+
+	chunks := strings.Split(p.query, delimiter)
+	// if we have more than 5 chunks, then we at least know that either there are duplicate keys, or there are some extra keys that we do not support
+	if len(chunks) > 5 {
+		return nil, fmt.Errorf("could not parse metric definition: %s", p.query)
+	}
+
+	queryParameters := NewQueryParameters()
+	for _, chunk := range chunks {
+		key, value, err := splitKeyValuePair(chunk)
+		if err != nil {
+			return nil, err
+		}
+
+		err = queryParameters.Add(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return queryParameters, nil
+}
+
+// splitKeyValuePair returns the split key-value pair or an error.
+// we do not allow empty values like 'key=' or just 'key'
+func splitKeyValuePair(keyValue string) (string, string, error) {
+	keyValue = strings.TrimSpace(keyValue)
+	if keyValue == "" {
+		return "", "", fmt.Errorf("empty key=value pair")
+	}
+
+	chunks := strings.Split(keyValue, keyValueDelimiter)
+	if len(chunks) != 2 || chunks[0] == "" || chunks[1] == "" {
+		return "", "", fmt.Errorf("could not parse 'key=value' pair correctly: %s", keyValue)
+	}
+
+	switch chunks[0] {
+	case metricSelectorKey, entitySelectorKey, resolutionKey, fromKey, toKey:
+		return chunks[0], chunks[1], nil
+	default:
+		return "", "", fmt.Errorf("unknown key in 'key=value' pair: %s", keyValue)
+	}
+}

--- a/internal/sli/metrics/query_parsing.go
+++ b/internal/sli/metrics/query_parsing.go
@@ -30,9 +30,8 @@ func (p *QueryParameters) Add(key string, value string) error {
 	return nil
 }
 
-func (p *QueryParameters) Get(key string) (string, bool) {
-	value, exists := p.values[key]
-	return value, exists
+func (p *QueryParameters) Get(key string) string {
+	return p.values[key]
 }
 
 // ForEach will iterate the QueryParameters in insertion order

--- a/internal/sli/metrics/query_parsing.go
+++ b/internal/sli/metrics/query_parsing.go
@@ -113,7 +113,7 @@ func (p *QueryParsing) Parse() (*QueryParameters, error) {
 func splitKeyValuePair(keyValue string) (string, string, error) {
 	keyValue = strings.TrimSpace(keyValue)
 	if keyValue == "" {
-		return "", "", fmt.Errorf("empty key=value pair")
+		return "", "", fmt.Errorf("empty 'key=value' pair")
 	}
 
 	chunks := strings.Split(keyValue, keyValueDelimiter)

--- a/internal/sli/metrics/query_parsing_test.go
+++ b/internal/sli/metrics/query_parsing_test.go
@@ -210,9 +210,7 @@ func assertEqual(t *testing.T, expected *QueryParameters, actual *QueryParameter
 
 func assertAllContained(t *testing.T, subset *QueryParameters, superset *QueryParameters) {
 	subset.ForEach(func(keyFromSubset string, valueFromSubset string) {
-		valueFromSuperSet, exists := superset.Get(keyFromSubset)
-		assert.True(t, exists, "key: %s does not exist in super set", keyFromSubset)
-		assert.Equal(t, valueFromSubset, valueFromSuperSet)
+		assert.Equal(t, valueFromSubset, superset.Get(keyFromSubset))
 	})
 }
 

--- a/internal/sli/metrics/query_parsing_test.go
+++ b/internal/sli/metrics/query_parsing_test.go
@@ -130,17 +130,17 @@ func TestParsingMetricQueryStringAndEncodingItAgainWorksAsExpected(t *testing.T)
 		{
 			name:           "standard service response time",
 			input:          "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
-			expectedResult: "metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29",
+			expectedResult: "entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29",
 		},
 		{
 			name:           "standard total error rate",
 			input:          "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
-			expectedResult: "metricSelector=builtin%3Aservice.errors.total.rate%3Amerge%28%22dt.entity.service%22%29%3Aavg&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29",
+			expectedResult: "entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29&metricSelector=builtin%3Aservice.errors.total.rate%3Amerge%28%22dt.entity.service%22%29%3Aavg",
 		},
 		{
 			name:           "uri reserved character '/' and spaces in entity selector",
 			input:          "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag2:tom / jerry)",
-			expectedResult: "metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29%2Ctag%28my_tag2%3Atom+%2F+jerry%29",
+			expectedResult: "entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29%2Ctag%28my_tag2%3Atom+%2F+jerry%29&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29",
 		},
 		{
 			name:           "uri reserved character '+' and spaces in metric selector",

--- a/internal/sli/metrics/query_parsing_test.go
+++ b/internal/sli/metrics/query_parsing_test.go
@@ -1,0 +1,229 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type keyValuePair struct {
+	key   string
+	value string
+}
+
+func createKeyValuePair(key string, value string) keyValuePair {
+	return keyValuePair{
+		key:   key,
+		value: value,
+	}
+}
+
+func TestParsingMetricQueryStringWorksAsExpected(t *testing.T) {
+	testConfigs := []struct {
+		name           string
+		input          string
+		expectedResult *QueryParameters
+		shouldFail     bool
+		errMessage     string
+	}{
+		{
+			name:  "standard service response time",
+			input: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
+			expectedResult: createExpectedResultFrom(
+				t,
+				createKeyValuePair("metricSelector", "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)"),
+				createKeyValuePair("entitySelector", "type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)"),
+			),
+		},
+		{
+			name:  "standard total error rate",
+			input: "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
+			expectedResult: createExpectedResultFrom(
+				t,
+				createKeyValuePair("metricSelector", "builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg"),
+				createKeyValuePair("entitySelector", "type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)"),
+			),
+		},
+		{
+			name:  "uri reserved character '/' and spaces in entity selector",
+			input: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag2:tom / jerry)",
+			expectedResult: createExpectedResultFrom(
+				t,
+				createKeyValuePair("metricSelector", "builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)"),
+				createKeyValuePair("entitySelector", "type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag2:tom / jerry)"),
+			),
+		},
+		{
+			name:  "uri reserved character '+' and spaces in metric selector",
+			input: "metricSelector=(calc:service.$rt_csm:filter(and(eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\"),in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")))):splitBy():avg:auto:sort(value(avg,descending)))/((calc:service.$reqcnt_csm:filter(and(in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")),eq(Dimension,\"request Act ions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\")))):splitBy():sum:auto:sort(value(sum,descending))/(1))",
+			expectedResult: createExpectedResultFrom(
+				t,
+				createKeyValuePair(
+					"metricSelector",
+					"(calc:service.$rt_csm:filter(and(eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\"),in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")))):splitBy():avg:auto:sort(value(avg,descending)))/((calc:service.$reqcnt_csm:filter(and(in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")),eq(Dimension,\"request Act ions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\")))):splitBy():sum:auto:sort(value(sum,descending))/(1))"),
+			),
+		},
+		// Error cases below
+		{
+			// actually a tag 'my_tag:tom & jerry' would be totally fine from a Dynatrace API perspective
+			name:       "uri reserved character '&' in entity selector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag:tom & jerry)",
+			shouldFail: true,
+			errMessage: "jerry",
+		},
+		{
+			name:       "no value for key entitySelector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector",
+			shouldFail: true,
+			errMessage: "entitySelector",
+		},
+		{
+			name:       "empty value for key entitySelector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=",
+			shouldFail: true,
+			errMessage: "entitySelector=",
+		},
+		{
+			name:       "empty key=value pair fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&",
+			shouldFail: true,
+			errMessage: "empty",
+		},
+		{
+			name:       "empty input with spaces fails",
+			input:      "   ",
+			shouldFail: true,
+			errMessage: "empty",
+		},
+		{
+			name:       "standard service response time with additional unknown key fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)&myKey=myValue",
+			shouldFail: true,
+			errMessage: "unknown key",
+		},
+	}
+	for _, testConfig := range testConfigs {
+		tc := testConfig
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := NewQueryParsing(tc.input).Parse()
+			if tc.shouldFail {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
+				assert.Contains(t, err.Error(), tc.errMessage)
+			} else {
+				assert.NoError(t, err)
+				assertEqual(t, tc.expectedResult, actual)
+				assert.Empty(t, tc.errMessage, "fix test setup")
+			}
+		})
+	}
+}
+
+func TestParsingMetricQueryStringAndEncodingItAgainWorksAsExpected(t *testing.T) {
+	testConfigs := []struct {
+		name           string
+		input          string
+		expectedResult string
+		shouldFail     bool
+		errMessage     string
+	}{
+		{
+			name:           "standard service response time",
+			input:          "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
+			expectedResult: "metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29",
+		},
+		{
+			name:           "standard total error rate",
+			input:          "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)",
+			expectedResult: "metricSelector=builtin%3Aservice.errors.total.rate%3Amerge%28%22dt.entity.service%22%29%3Aavg&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29",
+		},
+		{
+			name:           "uri reserved character '/' and spaces in entity selector",
+			input:          "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag2:tom / jerry)",
+			expectedResult: "metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2850%29&entitySelector=type%28SERVICE%29%2Ctag%28keptn_managed%29%2Ctag%28keptn_service%3Amy-service%29%2Ctag%28my_tag2%3Atom+%2F+jerry%29",
+		},
+		{
+			name:           "uri reserved character '+' and spaces in metric selector",
+			input:          "metricSelector=(calc:service.$rt_csm:filter(and(eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\"),in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")))):splitBy():avg:auto:sort(value(avg,descending)))/((calc:service.$reqcnt_csm:filter(and(in(\"dt.entity.service\",entitySelector(\"type(service),requestAttribute(~\"$svc_id~\")\")),eq(Dimension,\"request Actions.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave.BO_EC11_NewCustAdd+_06_EntrDtlsAndSave_Rest_customer-profile.\")))):splitBy():sum:auto:sort(value(sum,descending))/(1))",
+			expectedResult: "metricSelector=%28calc%3Aservice.%24rt_csm%3Afilter%28and%28eq%28Dimension%2C%22request+Actions.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave_Rest_customer-profile.%22%29%2Cin%28%22dt.entity.service%22%2CentitySelector%28%22type%28service%29%2CrequestAttribute%28~%22%24svc_id~%22%29%22%29%29%29%29%3AsplitBy%28%29%3Aavg%3Aauto%3Asort%28value%28avg%2Cdescending%29%29%29%2F%28%28calc%3Aservice.%24reqcnt_csm%3Afilter%28and%28in%28%22dt.entity.service%22%2CentitySelector%28%22type%28service%29%2CrequestAttribute%28~%22%24svc_id~%22%29%22%29%29%2Ceq%28Dimension%2C%22request+Actions.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave.BO_EC11_NewCustAdd%2B_06_EntrDtlsAndSave_Rest_customer-profile.%22%29%29%29%29%3AsplitBy%28%29%3Asum%3Aauto%3Asort%28value%28sum%2Cdescending%29%29%2F%281%29%29",
+		},
+		// Error cases below:
+		{
+			// actually a tag 'my_tag:tom & jerry' would be totally fine from a Dynatrace API perspective
+			name:       "uri reserved character '&' in entity selector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my_tag:tom & jerry)",
+			shouldFail: true,
+			errMessage: "jerry",
+		},
+		{
+			name:       "no value for key entitySelector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector",
+			shouldFail: true,
+			errMessage: "entitySelector",
+		},
+		{
+			name:       "empty value for key entitySelector fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=",
+			shouldFail: true,
+			errMessage: "entitySelector=",
+		},
+		{
+			name:       "empty key=value pair fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&",
+			shouldFail: true,
+			errMessage: "empty",
+		},
+		{
+			name:       "empty input with spaces fails",
+			input:      "   ",
+			shouldFail: true,
+			errMessage: "empty",
+		},
+		{
+			name:       "standard service response time with additional unknown key fails",
+			input:      "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service)&myKey=myValue",
+			shouldFail: true,
+			errMessage: "unknown key",
+		},
+	}
+	for _, testConfig := range testConfigs {
+		tc := testConfig
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := NewQueryParsing(tc.input).Parse()
+			if tc.shouldFail {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
+				assert.Contains(t, err.Error(), tc.errMessage)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, actual.Encode())
+				assert.Empty(t, tc.errMessage, "fix test setup")
+			}
+		})
+	}
+}
+
+func assertEqual(t *testing.T, expected *QueryParameters, actual *QueryParameters) {
+	assertAllContained(t, actual, expected)
+	assertAllContained(t, expected, actual)
+}
+
+func assertAllContained(t *testing.T, subset *QueryParameters, superset *QueryParameters) {
+	subset.ForEach(func(keyFromSubset string, valueFromSubset string) {
+		valueFromSuperSet, exists := superset.Get(keyFromSubset)
+		assert.True(t, exists, "key: %s does not exist in super set", keyFromSubset)
+		assert.Equal(t, valueFromSubset, valueFromSuperSet)
+	})
+}
+
+func createExpectedResultFrom(t *testing.T, mapEntries ...keyValuePair) *QueryParameters {
+	parameters := NewQueryParameters()
+	for _, entry := range mapEntries {
+		err := parameters.Add(entry.key, entry.value)
+		if err != nil {
+			assert.Fail(t, "incorrect test setup: %v", err)
+		}
+	}
+
+	return parameters
+}

--- a/internal/sli/metrics/query_parsing_test.go
+++ b/internal/sli/metrics/query_parsing_test.go
@@ -210,7 +210,9 @@ func assertEqual(t *testing.T, expected *QueryParameters, actual *QueryParameter
 
 func assertAllContained(t *testing.T, subset *QueryParameters, superset *QueryParameters) {
 	subset.ForEach(func(keyFromSubset string, valueFromSubset string) {
-		assert.Equal(t, valueFromSubset, superset.Get(keyFromSubset))
+		valueFromSuperset, exists := superset.get(keyFromSubset)
+		assert.True(t, exists)
+		assert.Equal(t, valueFromSubset, valueFromSuperset)
 	})
 }
 


### PR DESCRIPTION
this closes #571

metric queries are now parsed differently and in case we cannot do so correctly (see example below) we will return an error accordingly.

We will handle all URI reserved characters appropriately with the exception of `?` and `&` as those are necessary for the parsing logic. So any metric query that would include these two characters in e.g. *tags* or *filters* will fail.

**See two possible options for failing metric queries:**
```{yaml}
---
spec_version: '1.0'
indicators:
  error_rate: "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my-tag:why?)"
  response_time_p95: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_managed),tag(keptn_service:my-service),tag(my-tag:tom & jerry)"`
```