### PR TITLE
Fix service account name to dynatrace service

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -41,7 +41,6 @@ The following table lists the configurable parameters of the *dynatrace-service*
 | `imagePullSecrets` | Secrets to use for container registry credentials | `[]` |
 | `serviceAccount.create` | Enables the service account creation | `true` |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
-| `serviceAccount.name` | The name of the service account to use. | `""` |
 | `podAnnotations` | Annotations to add to the created pods | `{}` |
 | `podSecurityContext` | Set the pod security context (e.g. `fsgroups`) | `{}` |
 | `securityContext` | Set the security context (e.g. `runasuser`) | `{}` |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -50,14 +50,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "dynatrace-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "dynatrace-service.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "dynatrace-service.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "dynatrace-service.serviceAccountName" . }}
+      serviceAccountName: dynatrace-service
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "dynatrace-service.serviceAccountName" . }}
+  name: dynatrace-service
   labels:
     {{- include "dynatrace-service.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,7 +46,6 @@ imagePullSecrets: []                         # Secrets to use for container regi
 serviceAccount:
   create: true                               # Enables the service account creation
   annotations: {}                            # Annotations to add to the service account
-  name: ""                                   # The name of the service account to use.
 
 podAnnotations: {}                           # Annotations to add to the created pods
 


### PR DESCRIPTION
Fixes #587 

Fixing the service account name to ```dynatrace-service```, which is used by Keptn secret service 