### PR TITLE
fix: Custom Charting and Data Explorer dashboard tiles that return no data should produce a failed indicator value and be included in SLO objectives

### DIFF
--- a/internal/sli/dashboard/metrics_query_processing.go
+++ b/internal/sli/dashboard/metrics_query_processing.go
@@ -68,8 +68,9 @@ func (r *MetricsQueryProcessing) Process(noOfDimensionsInChart int, sloDefinitio
 
 	dataResultCount := len(singleResult.Data)
 	if dataResultCount == 0 {
-		log.Debug("No data for metric")
+		return createFailedTileResultFromSLODefinition(sloDefinition, metricQueryComponents.metricQuery, "Metrics query result has no data")
 	}
+
 	for _, singleDataEntry := range singleResult.Data {
 		//
 		// we need to generate the indicator name based on the base name + all dimensions, e.g: teststep_MYTESTSTEP, teststep_MYOTHERTESTSTEP

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
@@ -182,12 +182,11 @@ func TestEmptySLOAndSLIAreNotWritten(t *testing.T) {
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3AsplitBy%28%29%3Apercentile%2895.000000%29%3Anames&resolution=Inf&to=1632835299000",
 		"./testdata/sli_via_dashboard_test/response_time_p95_200_0_results.json")
 
-	// if an upload of sli would be triggered then this test would fail
-	rClient := &uploadWillFailResourceClientMock{t: t}
+	rClient := &uploadErrorResourceClientMock{t: t}
 
 	getSLIFinishedEventAssertionsFunc := func(t *testing.T, actual *keptnv2.GetSLIFinishedEventData) {
 		assert.EqualValues(t, keptnv2.ResultFailed, actual.Result)
-		assert.Contains(t, actual.Message, "any SLI results")
+		assert.Contains(t, actual.Message, "Metrics query result has no data")
 	}
 
 	runAndAssertThatDashboardTestIsCorrect(t, testGetSLIEventDataWithDefaultStartAndEnd, handler, rClient, getSLIFinishedEventAssertionsFunc, createFailedSLIResultAssertionsFunc(indicator))

--- a/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/dashboard.json
+++ b/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/dashboard.json
@@ -1,0 +1,118 @@
+{
+    "metadata": {
+      "configurationVersions": [
+        5
+      ],
+      "clusterVersion": "1.232.0.20211123-221708"
+    },
+    "id": "12345678-1111-4444-8888-123456789012",
+    "dashboardMetadata": {
+      "name": "dashboard",
+      "shared": false,
+      "owner": "",
+      "popularity": 1
+    },
+    "tiles": [      
+      {
+        "name": "sli=srt_service;pass=<10",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 494,
+          "left": 304,
+          "width": 304,
+          "height": 304
+        },
+        "tileFilter": {},
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "metric": "builtin:service.response.time",
+            "spaceAggregation": "AVG",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [],
+            "filterBy": {
+              "filterOperator": "AND",
+              "nestedFilters": [
+                {
+                  "filter": "dt.entity.service",
+                  "filterType": "ID",
+                  "filterOperator": "OR",
+                  "nestedFilters": [],
+                  "criteria": [
+                    {
+                      "value": "SERVICE-C33B8A4C73748469",
+                      "evaluator": "IN"
+                    }
+                  ]
+                }
+              ],
+              "criteria": []
+            },
+            "enabled": true
+          }
+        ],
+        "visualConfig": {
+          "type": "GRAPH_CHART",
+          "global": {
+            "seriesType": "LINE",
+            "hideLegend": false
+          },
+          "rules": [
+            {
+              "matcher": "A:",
+              "properties": {
+                "color": "DEFAULT"
+              },
+              "seriesOverrides": []
+            }
+          ],
+          "axes": {
+            "xAxis": {
+              "displayName": "",
+              "visible": true
+            },
+            "yAxes": [
+              {
+                "displayName": "",
+                "visible": true,
+                "min": "AUTO",
+                "max": "AUTO",
+                "position": "LEFT",
+                "queryIds": [
+                  "A"
+                ],
+                "defaultAxis": true
+              }
+            ]
+          },
+          "heatmapSettings": {},
+          "thresholds": [
+            {
+              "axisTarget": "LEFT",
+              "rules": [
+                {
+                  "color": "#7dc540"
+                },
+                {
+                  "color": "#f5d30f"
+                },
+                {
+                  "color": "#dc172a"
+                }
+              ],
+              "queryId": "",
+              "visible": true
+            }
+          ],
+          "tableSettings": {
+            "isThresholdBackgroundAppliedToCell": false
+          },
+          "graphChartSettings": {
+            "connectNulls": false
+          }
+        }
+      }
+    ]
+  }

--- a/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/metrics_builtin_service_response_time.json
+++ b/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/metrics_builtin_service_response_time.json
@@ -1,0 +1,53 @@
+{
+  "metricId": "builtin:service.response.time",
+  "displayName": "Response time",
+  "description": "",
+  "unit": "MicroSecond",
+  "dduBillable": false,
+  "created": 0,
+  "lastWritten": 1637671606633,
+  "entityType": [
+    "SERVICE"
+  ],
+  "aggregationTypes": [
+    "auto",
+    "avg",
+    "count",
+    "max",
+    "median",
+    "min",
+    "percentile",
+    "sum"
+  ],
+  "transformations": [
+    "filter",
+    "fold",
+    "limit",
+    "merge",
+    "names",
+    "parents",
+    "timeshift",
+    "sort",
+    "last",
+    "splitBy",
+    "lastReal"
+  ],
+  "defaultAggregation": {
+    "type": "avg"
+  },
+  "dimensionDefinitions": [
+    {
+      "key": "dt.entity.service",
+      "name": "Service",
+      "displayName": "Service",
+      "index": 0,
+      "type": "ENTITY"
+    }
+  ],
+  "tags": [],
+  "metricValueType": {
+    "type": "unknown"
+  },
+  "scalar": false,
+  "resolutionInfSupported": true
+}

--- a/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/metrics_query_builtin_service_response_time.json
+++ b/internal/sli/testdata/dashboards/slo_generation/data_explorer_tile_no_data/metrics_query_builtin_service_response_time.json
@@ -1,0 +1,11 @@
+{
+  "totalCount": 0,
+  "nextPageKey": null,
+  "resolution": "Inf",
+  "result": [
+    {
+      "metricId": "builtin:service.response.time:splitBy():avg:names",
+      "data": []
+    }
+  ]
+}


### PR DESCRIPTION
Closes #609