### PR TITLE
build: re-use validate semantic PR workflow from keptn/gh-automation

### DIFF
--- a/.github/workflows/validate-semantic-prs.yml
+++ b/.github/workflows/validate-semantic-prs.yml
@@ -10,39 +10,13 @@ defaults:
     shell: bash
 jobs:
   validate:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Validate Pull Request
-        uses: amannn/action-semantic-pull-request@ad47c64a77f00b53fe0a6b41d9a65f14c2e0b5fd # pin@v3.4.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed.
-          # Default: https://github.com/commitizen/conventional-commit-types
-          types: |
-            feat
-            fix
-            build
-            chore
-            ci
-            docs
-            perf
-            refactor
-            revert
-            style
-            test
-          # Configure which scopes are allowed.
-          scopes: |
-            api
-            core
-            install
-            deps
-            deps-dev
-            docs
-          # Configure that a scope must always be provided.
-          requireScope: false
-          # When using "Squash and merge" on a PR with only one commit, GitHub
-          # will suggest using that commit message instead of the PR title for the
-          # merge commit, and it's easy to commit this by mistake. Enable this option
-          # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@v1.4.0
+    with:
+      # Configure which scopes are allowed.
+      scopes: |
+        api
+        core
+        install
+        deps
+        deps-dev
+        docs


### PR DESCRIPTION
## This PR

- re-uses the validate semantic PR workflow from keptn/gh-automation

Part of #655