### PR TITLE
chore: Re-use docker-build action from keptn/gh-automation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -180,43 +180,31 @@ jobs:
         with:
           env-file: .ci_env
 
-      - id: docker_login
-        name: Docker Login
-        # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: (github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository)
-        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
-        # that's fine, but it means we can't push images to dockerhub
-        uses: docker/login-action@v1.12.0
+      - name: Docker Build
+        id: docker_build
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - id: docker_build
-        name: Docker Build
-        uses: keptn/gh-action-build-docker-image@master
-        with:
-          VERSION: ${{ env.VERSION }}
-          IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}"
-          DATETIME: ${{ env.DATETIME }}
-
-      - id: create_docker_build_report
-        name: Create Docker Build Report
-        run: |
-          echo "The following Docker Images have been built: " > docker_build_report_final.txt
-          cat docker_build_report.txt >> docker_build_report_final.txt || echo "* No images have been built or uploaded" >> docker_build_report_final.txt
-          echo "---"
-          cat docker_build_report_final.txt
+          TAGS: |
+            ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}.${{ env.DATETIME }}
+          BUILD_ARGS: |
+            version=${{ env.VERSION }}
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          PUSH: ${{(github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)}}
 
       - id: report_docker_build_to_pr
-        # Comment the docker build report to the PR
-        # This only works for PRs coming from inside of the repo, not from forks
         name: Report Docker Build to PR
-        if: (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.repository)
-        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          path: docker_build_report_final.txt
           recreate: true
+          header: test
+          message: |
+            The following Docker Images have been built:
+            ${{ fromJSON(steps.docker_build.outputs.BUILD_METADATA)['image.name'] }}
+
 
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -99,15 +99,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
       # load DOCKER_ORGANIZATION & IMAGE variable from .ci_env
       - name: Load CI Environment from .ci_env
         id: load_ci_env
@@ -115,17 +106,15 @@ jobs:
         with:
           env-file: .ci_env
 
-      - id: docker_build_image
-        name: "Docker Build and Push"
-        uses: docker/build-push-action@v2
+      - name: Docker Build
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
-          context: .
-          tags: |
+          TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}
-          build-args: |
+          BUILD_ARGS: |
             version=${{ env.VERSION }}
-          push: true
-          pull: true
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
   ############################################################################
   # Build Helm Chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
       # load DOCKER_ORGANIZATION & IMAGE variable from .ci_env
       - name: Load CI Environment from .ci_env
         id: load_ci_env
@@ -135,17 +126,15 @@ jobs:
         with:
           env-file: .ci_env
 
-      - id: docker_build_image
-        name: "Docker Build and Push"
-        uses: docker/build-push-action@v2
+      - name: Docker Build
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
-          context: .
-          tags: |
+          TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}
-          build-args: |
+          BUILD_ARGS: |
             version=${{ env.VERSION }}
-          push: true
-          pull: true
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
   ############################################################################
   # Build Helm Chart


### PR DESCRIPTION
## This PR

- re-uses the docker build action from keptn/gh-automation

**Note**: I have left out the part where we push images to ghcr.io, but I can easily add it if you want.

Part of #655