### PR TITLE
docs: Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you are planning to upgrade to dynatrace-service version `0.18.0` or newer fr
   - [Automatic onboarding of monitored service entities](documentation/auto-service-onboarding.md)
 - Other topics
   - [Additional installation options](documentation/additional-installation-options.md)
+  - [Dynatrace API token scopes](documentation/dynatrace-api-token-scopes.md)
   - [Keptn placeholders](documentation/keptn-placeholders.md)
   - [Automatic configuration of a Dynatrace tenant](documentation/auto-tenant-configuration.md)
   - [Upgrading the dynatrace-service](documentation/other-topics.md#upgrading-the-dynatrace-service)

--- a/documentation/dynatrace-api-token-scopes.md
+++ b/documentation/dynatrace-api-token-scopes.md
@@ -6,12 +6,12 @@ To interact with a Dynatrace tenant, the dynatrace-service requires access to th
 
 |Feature | Required scope(s)|
 |:--------|:-----------------|
-| [SLIs via `dynatrace/sli.yaml` files](documentation/slis-via-files.md) | - |
-| [SLIs via a Dynatrace dashboard](documentation/slis-via-dashboard.md) | Read configuration (`ReadConfig`)|
-| [Forwarding events from Keptn to Dynatrace](documentation/event-forwarding-to-dynatrace.md) | Access problem and event feed, metrics, and topology (`DataExport`) |
-| [Forwarding problem notifications from Dynatrace to Keptn](documentation/problem-forwarding-to-keptn.md) | - |
-| [Automatic onboarding of monitored service entities](documentation/auto-service-onboarding.md) | Read entities (`entities.read`) |
-| [Automatic configuration of a Dynatrace tenant](documentation/auto-tenant-configuration.md) | Read configuration (`ReadConfig`), Write configuration (`WriteConfig`) |
+| [SLIs via `dynatrace/sli.yaml` files](slis-via-files.md) | - |
+| [SLIs via a Dynatrace dashboard](slis-via-dashboard.md) | Read configuration (`ReadConfig`)|
+| [Forwarding events from Keptn to Dynatrace](event-forwarding-to-dynatrace.md) | Access problem and event feed, metrics, and topology (`DataExport`) |
+| [Forwarding problem notifications from Dynatrace to Keptn](problem-forwarding-to-keptn.md) | - |
+| [Automatic onboarding of monitored service entities](auto-service-onboarding.md) | Read entities (`entities.read`) |
+| [Automatic configuration of a Dynatrace tenant](auto-tenant-configuration.md) | Read configuration (`ReadConfig`), Write configuration (`WriteConfig`) |
 
 ## Scopes required for SLIs
 


### PR DESCRIPTION
Adds `dynatrace-api-token-scopes.md` to the table of contents and fixes some broken links.
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>