### PR TITLE
fix: Remove helm chart option for optional dynatrace-service container deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.dynatraceService.image.repository}}
         - name: dynatrace-service
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -99,7 +98,6 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        {{ end }}
         - name: distributor
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^$|^[a-z0-9][a-z0-9-./]{0,511}$"
+              "pattern": "^[a-z0-9][a-z0-9-./]{0,511}$"
             },
             "pullPolicy": {
               "enum": [


### PR DESCRIPTION
This removes the option for omitting the dynatrace-service container when deploying via Helm, introduced in #513, as this is now obsolete.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>