### PR TITLE
Lift distributor to 0.14.1

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,7 +31,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.10.0"                             # Container Tag
+    tag: "0.14.1"                             # Container Tag
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode


### PR DESCRIPTION
Lift distributor to 0.14.1 to solve the NATS URL change issue and make Dynatrace service compatible with Keptn 0.14.1