### PR TITLE
fix!: markdown processing returns errors

### DIFF
--- a/documentation/slis-via-dashboard.md
+++ b/documentation/slis-via-dashboard.md
@@ -108,6 +108,7 @@ By default, the dynatrace-service instructs Keptn to perform the evaluation of S
 ```yaml
 comparison:
   compare_with: "single_result"
+  number_of_comparison_results: 1
   include_result_with_score: "pass"
   aggregate_function: avg
 total_score:
@@ -119,13 +120,13 @@ Further details about SLO comparison and scoring are provided in [the Keptn docu
 
 To override these defaults, add a markdown tile to the dashboard with one or more of the following `;`-separated `<key>=<value>` pairs:
 
-| Key | Description |
-|---|---|
-|`KQG.Compare.Results` | Use `<value>` as the `comparison: compare_with` value |
-|`KQG.Compare.WithScore` | Use `<value>` as the `comparison: include_result_with_score` value |
-|`KQG.Compare.Function` | Use `<value>` as the `comparison: aggregate_function` value |
-|`KQG.Total.Pass` | Use `<value>` as the `total_score: pass` value |
-|`KQG.Total.Warning` | Use `<value>` as the `total_score: warning` value |
+| Key                     | Data type (restriction)                | Description                                                                                                                                          |
+|-------------------------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `KQG.Compare.Results`   | number (`> 0`)                         | Use `<value>` as the `comparison: number_of_comparison_results` value. `comparison: compare_with` will be set automatically according to this value. |
+| `KQG.Compare.WithScore` | string (`pass`, `all`, `pass_or_warn`) | Use `<value>` as the `comparison: include_result_with_score` value                                                                                   |
+| `KQG.Compare.Function`  | string (`avg`, `p50`, `p90`, `p95`)    | Use `<value>` as the `comparison: aggregate_function` value                                                                                          |
+| `KQG.Total.Pass`        | number (with optional `%`)             | Use `<value>` as the `total_score: pass` value                                                                                                       |
+| `KQG.Total.Warning`     | number (with optional `%`)             | Use `<value>` as the `total_score: warning` value                                                                                                    |
 
 For example, the defaults above could be specified using a markdown tile containing:
 

--- a/internal/sli/dashboard/dashboard_processing.go
+++ b/internal/sli/dashboard/dashboard_processing.go
@@ -70,7 +70,7 @@ func (p *Processing) Process(ctx context.Context, dashboard *dynatrace.Dashboard
 		},
 	}
 
-	log.Debug("Dashboard has changed: reparsing it!")
+	log.Debug("Dashboard will be parsed!")
 
 	// now let's iterate through the dashboard to find our SLIs
 	for _, tile := range dashboard.Tiles {

--- a/internal/sli/dashboard/dashboard_processing.go
+++ b/internal/sli/dashboard/dashboard_processing.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"fmt"
 
 	keptncommon "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -47,7 +48,7 @@ func NewProcessing(client dynatrace.ClientInterface, eventData adapter.EventCont
 }
 
 // Process processes a dynatrace.Dashboard.
-func (p *Processing) Process(ctx context.Context, dashboard *dynatrace.Dashboard) *QueryResult {
+func (p *Processing) Process(ctx context.Context, dashboard *dynatrace.Dashboard) (*QueryResult, error) {
 
 	// lets also generate the dashboard link for that timeframe (gtf=c_START_END) as well as management zone (gf=MZID) to pass back as label to Keptn
 	dashboardLinkAsLabel := NewLink(p.client.Credentials().GetTenant(), p.timeframe, dashboard.ID, dashboard.GetFilter())
@@ -73,13 +74,21 @@ func (p *Processing) Process(ctx context.Context, dashboard *dynatrace.Dashboard
 	log.Debug("Dashboard will be parsed!")
 
 	// now let's iterate through the dashboard to find our SLIs
+	markdownAlreadyProcessed := false
 	for _, tile := range dashboard.Tiles {
 		switch tile.TileType {
 		case dynatrace.MarkdownTileType:
-			score, comparison := NewMarkdownTileProcessing().Process(&tile, createDefaultSLOScore(), createDefaultSLOComparison())
-			if score != nil && comparison != nil {
-				result.slo.TotalScore = score
-				result.slo.Comparison = comparison
+			res, err := NewMarkdownTileProcessing().Process(&tile, createDefaultSLOScore(), createDefaultSLOComparison())
+			if err != nil {
+				return nil, fmt.Errorf("markdown tile parsing error: %w", err)
+			}
+			if res != nil {
+				if markdownAlreadyProcessed {
+					return nil, fmt.Errorf("only one markdown tile allowed for KQG configuration")
+				}
+				result.slo.TotalScore = &res.totalScore
+				result.slo.Comparison = &res.comparison
+				markdownAlreadyProcessed = true
 			}
 		case dynatrace.SLOTileType:
 			tileResults := NewSLOTileProcessing(p.client, p.timeframe).Process(ctx, &tile)
@@ -102,5 +111,5 @@ func (p *Processing) Process(ctx context.Context, dashboard *dynatrace.Dashboard
 		}
 	}
 
-	return result
+	return result, nil
 }

--- a/internal/sli/dashboard/dashboard_querying.go
+++ b/internal/sli/dashboard/dashboard_querying.go
@@ -38,5 +38,5 @@ func (q *Querying) GetSLIValues(ctx context.Context, dashboardID string, timefra
 		return nil, fmt.Errorf("error while processing dashboard config '%s' - %w", dashboardID, err)
 	}
 
-	return NewProcessing(q.dtClient, q.eventData, q.customSLIFilters, timeframe).Process(ctx, dashboard), nil
+	return NewProcessing(q.dtClient, q.eventData, q.customSLIFilters, timeframe).Process(ctx, dashboard)
 }

--- a/internal/sli/dashboard/markdown_tile_processing.go
+++ b/internal/sli/dashboard/markdown_tile_processing.go
@@ -61,20 +61,20 @@ func (p *MarkdownTileProcessing) Process(tile *dynatrace.Tile, defaultScore kept
 }
 
 const (
-	totalPass                  = "kqg.total.pass"
-	totalWarning               = "kqg.total.warning"
-	compareWithScore           = "kqg.compare.withscore"
-	compareWithScoreAll        = "all"
-	compareWithScorePass       = "pass"
-	compareWithScorePassOrWarn = "pass_or_warn"
-	compareResults             = "kqg.compare.results" // this is an int! You cannot specify 'single_result' or 'several results' at all -> it is derived from the number of results
-	compareResultsSingle       = "single_result"
-	compareResultsMultiple     = "several_results"
-	compareFunction            = "kqg.compare.function"
-	compareFunctionAvg         = "avg"
-	compareFunctionP50         = "p50"
-	compareFunctionP90         = "p90"
-	compareFunctionP95         = "p95"
+	TotalPass                  = "kqg.total.pass"
+	TotalWarning               = "kqg.total.warning"
+	CompareWithScore           = "kqg.compare.withscore"
+	CompareWithScoreAll        = "all"
+	CompareWithScorePass       = "pass"
+	CompareWithScorePassOrWarn = "pass_or_warn"
+	CompareResults             = "kqg.compare.results"
+	CompareResultsSingle       = "single_result"
+	CompareResultsMultiple     = "several_results"
+	CompareFunction            = "kqg.compare.function"
+	CompareFunctionAvg         = "avg"
+	CompareFunctionP50         = "p50"
+	CompareFunctionP90         = "p90"
+	CompareFunctionP95         = "p95"
 )
 
 // parseMarkdownConfiguration parses a text that can be used in a Markdown tile to specify global SLO properties
@@ -103,29 +103,29 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 		value := configValueSplits[1]
 
 		switch key {
-		case totalPass:
-			if keyFound[totalPass] {
-				errs = append(errs, &duplicateKeyError{key: totalPass})
+		case TotalPass:
+			if keyFound[TotalPass] {
+				errs = append(errs, &duplicateKeyError{key: TotalPass})
 				break
 			}
 			if isNotAPercentValue(value) {
-				errs = append(errs, &invalidValueError{key: totalPass, value: value})
+				errs = append(errs, &invalidValueError{key: TotalPass, value: value})
 			}
 			result.totalScore.Pass = value
-			keyFound[totalPass] = true
-		case totalWarning:
-			if keyFound[totalWarning] {
-				errs = append(errs, &duplicateKeyError{key: totalWarning})
+			keyFound[TotalPass] = true
+		case TotalWarning:
+			if keyFound[TotalWarning] {
+				errs = append(errs, &duplicateKeyError{key: TotalWarning})
 				break
 			}
 			if isNotAPercentValue(value) {
-				errs = append(errs, &invalidValueError{key: totalWarning, value: value})
+				errs = append(errs, &invalidValueError{key: TotalWarning, value: value})
 			}
 			result.totalScore.Warning = value
-			keyFound[totalWarning] = true
-		case compareWithScore:
-			if keyFound[compareWithScore] {
-				errs = append(errs, &duplicateKeyError{key: compareWithScore})
+			keyFound[TotalWarning] = true
+		case CompareWithScore:
+			if keyFound[CompareWithScore] {
+				errs = append(errs, &duplicateKeyError{key: CompareWithScore})
 				break
 			}
 			score, err := parseCompareWithScore(value)
@@ -133,10 +133,10 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 				errs = append(errs, err)
 			}
 			result.comparison.IncludeResultWithScore = score
-			keyFound[compareWithScore] = true
-		case compareResults:
-			if keyFound[compareResults] {
-				errs = append(errs, &duplicateKeyError{key: compareResults})
+			keyFound[CompareWithScore] = true
+		case CompareResults:
+			if keyFound[CompareResults] {
+				errs = append(errs, &duplicateKeyError{key: CompareResults})
 				break
 			}
 			numberOfResults, err := parseCompareNumberOfResults(value)
@@ -144,10 +144,10 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 				errs = append(errs, err)
 			}
 			result.comparison.NumberOfComparisonResults = numberOfResults
-			keyFound[compareResults] = true
-		case compareFunction:
-			if keyFound[compareFunction] {
-				errs = append(errs, &duplicateKeyError{key: compareFunction})
+			keyFound[CompareResults] = true
+		case CompareFunction:
+			if keyFound[CompareFunction] {
+				errs = append(errs, &duplicateKeyError{key: CompareFunction})
 				break
 			}
 			aggregateFunc, err := parseAggregateFunction(value)
@@ -155,7 +155,7 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 				errs = append(errs, err)
 			}
 			result.comparison.AggregateFunction = aggregateFunc
-			keyFound[compareFunction] = true
+			keyFound[CompareFunction] = true
 		}
 	}
 
@@ -165,9 +165,9 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 		}
 	}
 
-	result.comparison.CompareWith = compareResultsSingle
+	result.comparison.CompareWith = CompareResultsSingle
 	if result.comparison.NumberOfComparisonResults > 1 {
-		result.comparison.CompareWith = compareResultsMultiple
+		result.comparison.CompareWith = CompareResultsMultiple
 	}
 
 	return result, nil
@@ -181,21 +181,21 @@ func isNotAPercentValue(value string) bool {
 
 func parseCompareWithScore(value string) (string, error) {
 	switch value {
-	case compareWithScorePass, compareWithScoreAll, compareWithScorePassOrWarn:
+	case CompareWithScorePass, CompareWithScoreAll, CompareWithScorePassOrWarn:
 		return value, nil
 	}
 
-	return "", &invalidValueError{key: compareWithScore, value: value}
+	return "", &invalidValueError{key: CompareWithScore, value: value}
 }
 
 func parseCompareNumberOfResults(value string) (int, error) {
 	numberOfResults, err := strconv.Atoi(value)
 	if err != nil {
-		return 0, &invalidValueError{key: compareResults, value: value}
+		return 0, &invalidValueError{key: CompareResults, value: value}
 	}
 
 	if numberOfResults < 1 {
-		return 0, &invalidValueError{key: compareResults, value: value}
+		return 0, &invalidValueError{key: CompareResults, value: value}
 	}
 
 	return numberOfResults, nil
@@ -203,9 +203,9 @@ func parseCompareNumberOfResults(value string) (int, error) {
 
 func parseAggregateFunction(value string) (string, error) {
 	switch value {
-	case compareFunctionAvg, compareFunctionP50, compareFunctionP90, compareFunctionP95:
+	case CompareFunctionAvg, CompareFunctionP50, CompareFunctionP90, CompareFunctionP95:
 		return value, nil
 	}
 
-	return "", &invalidValueError{key: compareFunction, value: value}
+	return "", &invalidValueError{key: CompareFunction, value: value}
 }

--- a/internal/sli/dashboard/markdown_tile_processing.go
+++ b/internal/sli/dashboard/markdown_tile_processing.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -107,12 +108,18 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 				errs = append(errs, &duplicateKeyError{key: totalPass})
 				break
 			}
+			if isNotAPercentValue(value) {
+				errs = append(errs, &invalidValueError{key: totalPass, value: value})
+			}
 			result.totalScore.Pass = value
 			keyFound[totalPass] = true
 		case totalWarning:
 			if keyFound[totalWarning] {
 				errs = append(errs, &duplicateKeyError{key: totalWarning})
 				break
+			}
+			if isNotAPercentValue(value) {
+				errs = append(errs, &invalidValueError{key: totalWarning, value: value})
 			}
 			result.totalScore.Warning = value
 			keyFound[totalWarning] = true
@@ -164,6 +171,12 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 	}
 
 	return result, nil
+}
+
+func isNotAPercentValue(value string) bool {
+	pattern := regexp.MustCompile("^(\\d+|\\d+\\.\\d+)([%]?)$")
+
+	return !pattern.MatchString(value)
 }
 
 func parseCompareWithScore(value string) (string, error) {

--- a/internal/sli/dashboard/markdown_tile_processing.go
+++ b/internal/sli/dashboard/markdown_tile_processing.go
@@ -1,11 +1,40 @@
 package dashboard
 
 import (
-	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	keptncommon "github.com/keptn/go-utils/pkg/lib"
+	"fmt"
 	"strconv"
 	"strings"
+
+	keptncommon "github.com/keptn/go-utils/pkg/lib"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 )
+
+type markdownParsingErrors struct {
+	errors []error
+}
+
+func (err *markdownParsingErrors) Error() string {
+	var errStrings = make([]string, len(err.errors))
+	for i, e := range err.errors {
+		errStrings[i] = e.Error()
+	}
+	return strings.Join(errStrings, ";")
+}
+
+type invalidValueError struct {
+	key   string
+	value string
+}
+
+func (err *invalidValueError) Error() string {
+	return fmt.Sprintf("invalid value for '%s': %s", err.key, err.value)
+}
+
+type markdownParsingResult struct {
+	totalScore keptncommon.SLOScore
+	comparison keptncommon.SLOComparison
+}
 
 type MarkdownTileProcessing struct {
 }
@@ -16,17 +45,41 @@ func NewMarkdownTileProcessing() *MarkdownTileProcessing {
 }
 
 // Process will overwrite the default values for SLOScore and SLOComparison with the contents found in the markdown
-func (p *MarkdownTileProcessing) Process(tile *dynatrace.Tile, defaultScore keptncommon.SLOScore, defaultComparison keptncommon.SLOComparison) (*keptncommon.SLOScore, *keptncommon.SLOComparison) {
+func (p *MarkdownTileProcessing) Process(tile *dynatrace.Tile, defaultScore keptncommon.SLOScore, defaultComparison keptncommon.SLOComparison) (*markdownParsingResult, error) {
 	// we allow the user to use a markdown to specify SLI/SLO properties, e.g: KQG.Total.Pass
 	// if we find KQG. we process the markdown
 	return parseMarkdownConfiguration(tile.Markdown, defaultScore, defaultComparison)
 }
 
+const (
+	totalPass                  = "kqg.total.pass"
+	totalWarning               = "kqg.total.warning"
+	compareWithScore           = "kqg.compare.withscore"
+	compareWithScoreAll        = "all"
+	compareWithScorePass       = "pass"
+	compareWithScorePassOrWarn = "pass_or_warn"
+	compareResults             = "kqg.compare.results" // this is an int! You cannot specify 'single_result' or 'several results' at all -> it is derived from the number of results
+	compareResultsSingle       = "single_result"
+	compareResultsMultiple     = "several_results"
+	compareFunction            = "kqg.compare.function"
+	compareFunctionAvg         = "avg"
+	compareFunctionP50         = "p50"
+	compareFunctionP90         = "p90"
+	compareFunctionP95         = "p95"
+)
+
 // parseMarkdownConfiguration parses a text that can be used in a Markdown tile to specify global SLO properties
-func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore, comparison keptncommon.SLOComparison) (*keptncommon.SLOScore, *keptncommon.SLOComparison) {
+func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore, comparison keptncommon.SLOComparison) (*markdownParsingResult, error) {
 	if !strings.Contains(markdown, "KQG.") {
 		return nil, nil
 	}
+
+	result := &markdownParsingResult{
+		totalScore: totalScore,
+		comparison: comparison,
+	}
+
+	var errs []error
 
 	markdownSplits := strings.Split(markdown, ";")
 	for _, markdownSplitValue := range markdownSplits {
@@ -35,42 +88,77 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 			continue
 		}
 
-		// lets get configname and value
-		configName := strings.ToLower(configValueSplits[0])
-		configValue := configValueSplits[1]
+		// lets separate key and value
+		key := strings.ToLower(configValueSplits[0])
+		value := configValueSplits[1]
 
-		switch configName {
-		case "kqg.total.pass":
-			totalScore.Pass = configValue
-		case "kqg.total.warning":
-			totalScore.Warning = configValue
-		case "kqg.compare.withscore":
-			comparison.IncludeResultWithScore = configValue
-			if (configValue == "pass") || (configValue == "pass_or_warn") || (configValue == "all") {
-				comparison.IncludeResultWithScore = configValue
-			} else {
-				comparison.IncludeResultWithScore = "pass"
-			}
-		case "kqg.compare.results":
-			noresults, err := strconv.Atoi(configValue)
+		switch key {
+		case totalPass:
+			result.totalScore.Pass = value
+		case totalWarning:
+			result.totalScore.Warning = value
+		case compareWithScore:
+			score, err := parseCompareWithScore(value)
 			if err != nil {
-				comparison.NumberOfComparisonResults = 1
-			} else {
-				comparison.NumberOfComparisonResults = noresults
+				errs = append(errs, err)
 			}
-			if comparison.NumberOfComparisonResults > 1 {
-				comparison.CompareWith = "several_results"
-			} else {
-				comparison.CompareWith = "single_result"
+			result.comparison.IncludeResultWithScore = score
+		case compareResults:
+			numberOfResults, err := parseCompareNumberOfResults(value)
+			if err != nil {
+				errs = append(errs, err)
 			}
-		case "kqg.compare.function":
-			if (configValue == "avg") || (configValue == "p50") || (configValue == "p90") || (configValue == "p95") {
-				comparison.AggregateFunction = configValue
-			} else {
-				comparison.AggregateFunction = "avg"
+			result.comparison.NumberOfComparisonResults = numberOfResults
+		case compareFunction:
+			aggregateFunc, err := parseAggregateFunction(value)
+			if err != nil {
+				errs = append(errs, err)
 			}
+			result.comparison.AggregateFunction = aggregateFunc
 		}
 	}
 
-	return &totalScore, &comparison
+	if len(errs) > 0 {
+		return nil, &markdownParsingErrors{
+			errors: errs,
+		}
+	}
+
+	result.comparison.CompareWith = compareResultsSingle
+	if result.comparison.NumberOfComparisonResults > 1 {
+		result.comparison.CompareWith = compareResultsMultiple
+	}
+
+	return result, nil
+}
+
+func parseCompareWithScore(value string) (string, error) {
+	switch value {
+	case compareWithScorePass, compareWithScoreAll, compareWithScorePassOrWarn:
+		return value, nil
+	}
+
+	return "", &invalidValueError{key: compareWithScore, value: value}
+}
+
+func parseCompareNumberOfResults(value string) (int, error) {
+	numberOfResults, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, &invalidValueError{key: compareResults, value: value}
+	}
+
+	if numberOfResults < 1 {
+		return 0, &invalidValueError{key: compareResults, value: value}
+	}
+
+	return numberOfResults, nil
+}
+
+func parseAggregateFunction(value string) (string, error) {
+	switch value {
+	case compareFunctionAvg, compareFunctionP50, compareFunctionP90, compareFunctionP95:
+		return value, nil
+	}
+
+	return "", &invalidValueError{key: compareFunction, value: value}
 }

--- a/internal/sli/dashboard/markdown_tile_processing_test.go
+++ b/internal/sli/dashboard/markdown_tile_processing_test.go
@@ -1,88 +1,115 @@
 package dashboard
 
 import (
+	"testing"
+
 	keptnapi "github.com/keptn/go-utils/pkg/lib"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
-func TestParseMarkdownConfigurationParams(t *testing.T) {
+func TestParseMarkdownConfigurationParams_SuccessCases(t *testing.T) {
 	testConfigs := []struct {
+		name               string
 		input              string
-		expectedScore      *keptnapi.SLOScore
-		expectedComparison *keptnapi.SLOComparison
+		expectedScore      keptnapi.SLOScore
+		expectedComparison keptnapi.SLOComparison
 	}{
-		// single result
 		{
-			"KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
-			createSLOScore("90%", "70%"),
-			createSLOComparison("single_result", "pass", 1, "avg"),
+			name:               "single result",
+			input:              "KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedScore:      createSLOScore("90%", "70%"),
+			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
 		},
-		// several results, p50
+		//
 		{
-			"KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
-			createSLOScore("91%", "71%"),
-			createSLOComparison("several_results", "pass", 2, "p50"),
+			name:               "several results p50",
+			input:              "KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
+			expectedScore:      createSLOScore("91%", "71%"),
+			expectedComparison: createSLOComparison("several_results", "pass", 2, "p50"),
 		},
-		// several results, p90
+		//
 		{
-			"KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
-			createSLOScore("92%", "72%"),
-			createSLOComparison("several_results", "pass", 3, "p90"),
+			name:               "several results p90",
+			input:              "KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
+			expectedScore:      createSLOScore("92%", "72%"),
+			expectedComparison: createSLOComparison("several_results", "pass", 3, "p90"),
 		},
-		// several results, p95
+		//
 		{
-			"KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
-			createSLOScore("93%", "73%"),
-			createSLOComparison("several_results", "pass", 4, "p95"),
+			name:               "several results p95",
+			input:              "KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
+			expectedScore:      createSLOScore("93%", "73%"),
+			expectedComparison: createSLOComparison("several_results", "pass", 4, "p95"),
 		},
-		// several results, p95, all
+		//
 		{
-			"KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
-			createSLOScore("94%", "74%"),
-			createSLOComparison("several_results", "all", 5, "p95"),
+			name:               "several results p95 all",
+			input:              "KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
+			expectedScore:      createSLOScore("94%", "74%"),
+			expectedComparison: createSLOComparison("several_results", "all", 5, "p95"),
 		},
-		// several results, p95, pass_or_warn
+		//
 		{
-			"KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
-			createSLOScore("95%", "75%"),
-			createSLOComparison("several_results", "pass_or_warn", 6, "p95"),
-		},
-		// several results, p95, fallback to pass if compare function is unknown
-		{
-			"KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=warn;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			createSLOScore("96%", "76%"),
-			createSLOComparison("several_results", "pass", 7, "p95"),
-		},
-		// several results, fallback if function is unknown e.g. p97
-		{
-			"KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=8;KQG.Compare.Function=p97",
-			createSLOScore("97%", "77%"),
-			createSLOComparison("several_results", "pass", 8, "avg"),
-		},
-		// several results, fallback if function is unknown e.g. p97, ignore dashboard query behaviour
-		{
-			"KQG.Total.Pass=98%;KQG.Total.Warning=78%;KQG.Compare.WithScore=pass;KQG.Compare.Results=9;KQG.Compare.Function=p97;KQG.QueryBehavior=ParseOnChange",
-			createSLOScore("98%", "78%"),
-			createSLOComparison("several_results", "pass", 9, "avg"),
+			name:               "several results p95 pass_or_warn",
+			input:              "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
+			expectedScore:      createSLOScore("95%", "75%"),
+			expectedComparison: createSLOComparison("several_results", "pass_or_warn", 6, "p95"),
 		},
 	}
 	for _, config := range testConfigs {
-		actualScore, actualComparison := parseMarkdownConfiguration(config.input, createDefaultSLOScore(), createDefaultSLOComparison())
-
-		assert.EqualValues(t, config.expectedScore, actualScore)
-		assert.EqualValues(t, config.expectedComparison, actualComparison)
+		t.Run(config.name, func(t *testing.T) {
+			result, err := parseMarkdownConfiguration(config.input, createDefaultSLOScore(), createDefaultSLOComparison())
+			if assert.NoError(t, err) {
+				assert.EqualValues(t, config.expectedScore, result.totalScore)
+				assert.EqualValues(t, config.expectedComparison, result.comparison)
+			}
+		})
 	}
 }
 
-func createSLOScore(pass string, warning string) *keptnapi.SLOScore {
-	return &keptnapi.SLOScore{
+func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
+	testConfigs := []struct {
+		name             string
+		input            string
+		expectedMessages []string
+	}{
+		{
+			name:             "unknown compare with score function",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=warn;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.compare.withscore", "warn"},
+		},
+		{
+			name:             "unknown compare function, p97",
+			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=8;KQG.Compare.Function=p97",
+			expectedMessages: []string{"kqg.compare.function", "p97"},
+		},
+		{
+			name:             "wrong number of results, 0",
+			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=0;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.compare.results", "0"},
+		},
+	}
+	for _, config := range testConfigs {
+		t.Run(config.name, func(t *testing.T) {
+			result, err := parseMarkdownConfiguration(config.input, createDefaultSLOScore(), createDefaultSLOComparison())
+			if assert.Error(t, err) {
+				assert.Nil(t, result)
+				for _, msg := range config.expectedMessages {
+					assert.Contains(t, err.Error(), msg)
+				}
+			}
+		})
+	}
+}
+
+func createSLOScore(pass string, warning string) keptnapi.SLOScore {
+	return keptnapi.SLOScore{
 		Pass:    pass,
 		Warning: warning,
 	}
 }
-func createSLOComparison(compareWith string, include string, numberOfResults int, aggregateFunc string) *keptnapi.SLOComparison {
-	return &keptnapi.SLOComparison{
+func createSLOComparison(compareWith string, include string, numberOfResults int, aggregateFunc string) keptnapi.SLOComparison {
+	return keptnapi.SLOComparison{
 		CompareWith:               compareWith,
 		IncludeResultWithScore:    include,
 		NumberOfComparisonResults: numberOfResults,

--- a/internal/sli/dashboard/markdown_tile_processing_test.go
+++ b/internal/sli/dashboard/markdown_tile_processing_test.go
@@ -88,6 +88,31 @@ func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
 			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=0;KQG.Compare.Function=p95",
 			expectedMessages: []string{"kqg.compare.results", "0"},
 		},
+		{
+			name:             "duplicate total pass",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Pass=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.total.pass", "duplicate key"},
+		},
+		{
+			name:             "duplicate total warning",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Warning=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.total.warning", "duplicate key"},
+		},
+		{
+			name:             "duplicate total compare with score",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.WithScore=all",
+			expectedMessages: []string{"kqg.compare.withscore", "duplicate key"},
+		},
+		{
+			name:             "duplicate compare results",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Results=1",
+			expectedMessages: []string{"kqg.compare.results", "duplicate key"},
+		},
+		{
+			name:             "duplicate total compare function",
+			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Function=p90",
+			expectedMessages: []string{"kqg.compare.function", "duplicate key"},
+		},
 	}
 	for _, config := range testConfigs {
 		t.Run(config.name, func(t *testing.T) {

--- a/internal/sli/dashboard/markdown_tile_processing_test.go
+++ b/internal/sli/dashboard/markdown_tile_processing_test.go
@@ -15,6 +15,24 @@ func TestParseMarkdownConfigurationParams_SuccessCases(t *testing.T) {
 		expectedComparison keptnapi.SLOComparison
 	}{
 		{
+			name:               "single result, without percent sign",
+			input:              "KQG.Total.Pass=90;KQG.Total.Warning=70;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedScore:      createSLOScore("90", "70"),
+			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+		},
+		{
+			name:               "single result, without percent sign, with decimals",
+			input:              "KQG.Total.Pass=90.84;KQG.Total.Warning=70.22;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedScore:      createSLOScore("90.84", "70.22"),
+			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+		},
+		{
+			name:               "single result, with percent sign, with decimals",
+			input:              "KQG.Total.Pass=90.84%;KQG.Total.Warning=70.22%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedScore:      createSLOScore("90.84%", "70.22%"),
+			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+		},
+		{
 			name:               "single result",
 			input:              "KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedScore:      createSLOScore("90%", "70%"),
@@ -112,6 +130,16 @@ func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
 			name:             "duplicate total compare function",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Function=p90",
 			expectedMessages: []string{"kqg.compare.function", "duplicate key"},
+		},
+		{
+			name:             "invalid value for total pass",
+			input:            "KQG.Total.Pass=96Pct",
+			expectedMessages: []string{"kqg.total.pass", "96Pct"},
+		},
+		{
+			name:             "invalid value for total warning",
+			input:            "KQG.Total.Warning=OneHundred",
+			expectedMessages: []string{"kqg.total.warning", "OneHundred"},
 		},
 	}
 	for _, config := range testConfigs {

--- a/internal/sli/dashboard/markdown_tile_processing_test.go
+++ b/internal/sli/dashboard/markdown_tile_processing_test.go
@@ -18,55 +18,55 @@ func TestParseMarkdownConfigurationParams_SuccessCases(t *testing.T) {
 			name:               "single result, without percent sign",
 			input:              "KQG.Total.Pass=90;KQG.Total.Warning=70;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedScore:      createSLOScore("90", "70"),
-			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+			expectedComparison: createSLOComparison(CompareResultsSingle, CompareWithScorePass, 1, CompareFunctionAvg),
 		},
 		{
 			name:               "single result, without percent sign, with decimals",
 			input:              "KQG.Total.Pass=90.84;KQG.Total.Warning=70.22;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedScore:      createSLOScore("90.84", "70.22"),
-			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+			expectedComparison: createSLOComparison(CompareResultsSingle, CompareWithScorePass, 1, CompareFunctionAvg),
 		},
 		{
 			name:               "single result, with percent sign, with decimals",
 			input:              "KQG.Total.Pass=90.84%;KQG.Total.Warning=70.22%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedScore:      createSLOScore("90.84%", "70.22%"),
-			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+			expectedComparison: createSLOComparison(CompareResultsSingle, CompareWithScorePass, 1, CompareFunctionAvg),
 		},
 		{
 			name:               "single result",
 			input:              "KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedScore:      createSLOScore("90%", "70%"),
-			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
+			expectedComparison: createSLOComparison(CompareResultsSingle, CompareWithScorePass, 1, CompareFunctionAvg),
 		},
 		{
 			name:               "several results p50",
 			input:              "KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
 			expectedScore:      createSLOScore("91%", "71%"),
-			expectedComparison: createSLOComparison("several_results", "pass", 2, "p50"),
+			expectedComparison: createSLOComparison(CompareResultsMultiple, CompareWithScorePass, 2, CompareFunctionP50),
 		},
 		{
 			name:               "several results p90",
 			input:              "KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
 			expectedScore:      createSLOScore("92%", "72%"),
-			expectedComparison: createSLOComparison("several_results", "pass", 3, "p90"),
+			expectedComparison: createSLOComparison(CompareResultsMultiple, CompareWithScorePass, 3, CompareFunctionP90),
 		},
 		{
 			name:               "several results p95",
 			input:              "KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
 			expectedScore:      createSLOScore("93%", "73%"),
-			expectedComparison: createSLOComparison("several_results", "pass", 4, "p95"),
+			expectedComparison: createSLOComparison(CompareResultsMultiple, CompareWithScorePass, 4, CompareFunctionP95),
 		},
 		{
 			name:               "several results p95 all",
 			input:              "KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
 			expectedScore:      createSLOScore("94%", "74%"),
-			expectedComparison: createSLOComparison("several_results", "all", 5, "p95"),
+			expectedComparison: createSLOComparison(CompareResultsMultiple, CompareWithScoreAll, 5, CompareFunctionP95),
 		},
 		{
 			name:               "several results p95 pass_or_warn",
 			input:              "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
 			expectedScore:      createSLOScore("95%", "75%"),
-			expectedComparison: createSLOComparison("several_results", "pass_or_warn", 6, "p95"),
+			expectedComparison: createSLOComparison(CompareResultsMultiple, CompareWithScorePassOrWarn, 6, CompareFunctionP95),
 		},
 	}
 	for _, config := range testConfigs {
@@ -81,6 +81,8 @@ func TestParseMarkdownConfigurationParams_SuccessCases(t *testing.T) {
 }
 
 func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
+	const duplicationError = "duplicate key"
+
 	testConfigs := []struct {
 		name             string
 		input            string
@@ -89,72 +91,72 @@ func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
 		{
 			name:             "unknown compare with score function",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=warn;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.compare.withscore", "warn"},
+			expectedMessages: []string{CompareWithScore, "warn"},
 		},
 		{
 			name:             "unknown compare function, p97",
 			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=8;KQG.Compare.Function=p97",
-			expectedMessages: []string{"kqg.compare.function", "p97"},
+			expectedMessages: []string{CompareFunction, "p97"},
 		},
 		{
 			name:             "wrong number of results, 0",
 			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=0;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.compare.results", "0"},
+			expectedMessages: []string{CompareResults, "0"},
 		},
 		{
 			name:             "wrong number of results, decimal",
 			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7.5;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.compare.results", "7.5"},
+			expectedMessages: []string{CompareResults, "7.5"},
 		},
 		{
 			name:             "wrong number of results, string",
 			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=three;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.compare.results", "three"},
+			expectedMessages: []string{CompareResults, "three"},
 		},
 		{
 			name:             "duplicate total pass",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Pass=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.total.pass", "duplicate key"},
+			expectedMessages: []string{TotalPass, duplicationError},
 		},
 		{
 			name:             "duplicate total warning",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Warning=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			expectedMessages: []string{"kqg.total.warning", "duplicate key"},
+			expectedMessages: []string{TotalWarning, duplicationError},
 		},
 		{
 			name:             "duplicate total compare with score",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.WithScore=all",
-			expectedMessages: []string{"kqg.compare.withscore", "duplicate key"},
+			expectedMessages: []string{CompareWithScore, duplicationError},
 		},
 		{
 			name:             "duplicate compare results",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Results=1",
-			expectedMessages: []string{"kqg.compare.results", "duplicate key"},
+			expectedMessages: []string{CompareResults, duplicationError},
 		},
 		{
 			name:             "duplicate total compare function",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Function=p90",
-			expectedMessages: []string{"kqg.compare.function", "duplicate key"},
+			expectedMessages: []string{CompareFunction, duplicationError},
 		},
 		{
 			name:             "invalid value for total pass",
 			input:            "KQG.Total.Pass=96Pct",
-			expectedMessages: []string{"kqg.total.pass", "96Pct"},
+			expectedMessages: []string{TotalPass, "96Pct"},
 		},
 		{
 			name:             "invalid value for total warning",
 			input:            "KQG.Total.Warning=OneHundred",
-			expectedMessages: []string{"kqg.total.warning", "OneHundred"},
+			expectedMessages: []string{TotalWarning, "OneHundred"},
 		},
 		{
 			name:  "multiple problems - one for each",
 			input: "KQG.Total.Pass=96Pct;KQG.Total.Warning=OneHundred;KQG.Compare.WithScore=passing;KQG.Compare.Results=7.5;KQG.Compare.Function=p97;",
 			expectedMessages: []string{
-				"kqg.total.pass", "96Pct",
-				"kqg.total.warning", "OneHundred",
-				"kqg.compare.withscore", "passing",
-				"kqg.compare.function", "p97",
-				"kqg.compare.results", "7.5",
+				TotalPass, "96Pct",
+				TotalWarning, "OneHundred",
+				CompareWithScore, "passing",
+				CompareFunction, "p97",
+				CompareResults, "7.5",
 			},
 		},
 	}

--- a/internal/sli/dashboard/markdown_tile_processing_test.go
+++ b/internal/sli/dashboard/markdown_tile_processing_test.go
@@ -38,35 +38,30 @@ func TestParseMarkdownConfigurationParams_SuccessCases(t *testing.T) {
 			expectedScore:      createSLOScore("90%", "70%"),
 			expectedComparison: createSLOComparison("single_result", "pass", 1, "avg"),
 		},
-		//
 		{
 			name:               "several results p50",
 			input:              "KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
 			expectedScore:      createSLOScore("91%", "71%"),
 			expectedComparison: createSLOComparison("several_results", "pass", 2, "p50"),
 		},
-		//
 		{
 			name:               "several results p90",
 			input:              "KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
 			expectedScore:      createSLOScore("92%", "72%"),
 			expectedComparison: createSLOComparison("several_results", "pass", 3, "p90"),
 		},
-		//
 		{
 			name:               "several results p95",
 			input:              "KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
 			expectedScore:      createSLOScore("93%", "73%"),
 			expectedComparison: createSLOComparison("several_results", "pass", 4, "p95"),
 		},
-		//
 		{
 			name:               "several results p95 all",
 			input:              "KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
 			expectedScore:      createSLOScore("94%", "74%"),
 			expectedComparison: createSLOComparison("several_results", "all", 5, "p95"),
 		},
-		//
 		{
 			name:               "several results p95 pass_or_warn",
 			input:              "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
@@ -107,6 +102,16 @@ func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
 			expectedMessages: []string{"kqg.compare.results", "0"},
 		},
 		{
+			name:             "wrong number of results, decimal",
+			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7.5;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.compare.results", "7.5"},
+		},
+		{
+			name:             "wrong number of results, string",
+			input:            "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=three;KQG.Compare.Function=p95",
+			expectedMessages: []string{"kqg.compare.results", "three"},
+		},
+		{
 			name:             "duplicate total pass",
 			input:            "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Pass=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
 			expectedMessages: []string{"kqg.total.pass", "duplicate key"},
@@ -140,6 +145,17 @@ func TestParseMarkdownConfigurationParams_ErrorCases(t *testing.T) {
 			name:             "invalid value for total warning",
 			input:            "KQG.Total.Warning=OneHundred",
 			expectedMessages: []string{"kqg.total.warning", "OneHundred"},
+		},
+		{
+			name:  "multiple problems - one for each",
+			input: "KQG.Total.Pass=96Pct;KQG.Total.Warning=OneHundred;KQG.Compare.WithScore=passing;KQG.Compare.Results=7.5;KQG.Compare.Function=p97;",
+			expectedMessages: []string{
+				"kqg.total.pass", "96Pct",
+				"kqg.total.warning", "OneHundred",
+				"kqg.compare.withscore", "passing",
+				"kqg.compare.function", "p97",
+				"kqg.compare.results", "7.5",
+			},
 		},
 	}
 	for _, config := range testConfigs {

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
@@ -1,0 +1,218 @@
+package sli
+
+import (
+	"testing"
+
+	keptnapi "github.com/keptn/go-utils/pkg/lib"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
+	"github.com/keptn-contrib/dynatrace-service/internal/test"
+)
+
+type data struct {
+	Markdown string // needs to match template file variable
+}
+
+// TestRetrieveMetricsFromDashboard_MarkdownParsingWorks test lots of markdown tiles without errors in the SLO definition.
+// there is one SLO tile as well to have a fully working example where SLOs would be stored as well
+func TestRetrieveMetricsFromDashboard_MarkdownParsingWorks(t *testing.T) {
+	const templateFile = "./testdata/dashboards/markdown/markdown-tile-parsing-single-sli-template.json"
+	assertionFunc := createSuccessfulSLIResultAssertionsFunc("Static_SLO_-_Pass", 95)
+
+	expectedSLO := &keptnapi.SLO{
+		SLI:     "Static_SLO_-_Pass",
+		Pass:    []*keptnapi.SLOCriteria{{Criteria: []string{">=90.000000"}}},
+		Warning: []*keptnapi.SLOCriteria{{Criteria: []string{">=75.000000"}}},
+		Weight:  1,
+		KeySLI:  false,
+	}
+
+	tests := []struct {
+		name        string
+		markdown    string
+		expectedSLO *keptnapi.ServiceLevelObjectives
+	}{
+		{
+			name:        "only defaults",
+			markdown:    "just some information here, that does not add any configuration",
+			expectedSLO: createSLO("90%", "75%", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "single result, without percent sign",
+			markdown:    "KQG.Total.Pass=90;KQG.Total.Warning=70;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedSLO: createSLO("90", "70", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "single result, without percent sign, with decimals",
+			markdown:    "KQG.Total.Pass=90.84;KQG.Total.Warning=70.22;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedSLO: createSLO("90.84", "70.22", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "single result, with percent sign, with decimals",
+			markdown:    "KQG.Total.Pass=90.84%;KQG.Total.Warning=70.22%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedSLO: createSLO("90.84%", "70.22%", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "single result",
+			markdown:    "KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
+			expectedSLO: createSLO("90%", "70%", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "several results p50",
+			markdown:    "KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
+			expectedSLO: createSLO("91%", "71%", "several_results", "pass", 2, "p50", expectedSLO),
+		},
+		{
+			name:        "several results p90",
+			markdown:    "KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
+			expectedSLO: createSLO("92%", "72%", "several_results", "pass", 3, "p90", expectedSLO),
+		},
+		{
+			name:        "several results p95",
+			markdown:    "KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
+			expectedSLO: createSLO("93%", "73%", "several_results", "pass", 4, "p95", expectedSLO),
+		},
+		{
+			name:        "several results p95 all",
+			markdown:    "KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
+			expectedSLO: createSLO("94%", "74%", "several_results", "all", 5, "p95", expectedSLO),
+		},
+		{
+			name:        "several results p95 pass_or_warn",
+			markdown:    "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
+			expectedSLO: createSLO("95%", "75%", "several_results", "pass_or_warn", 6, "p95", expectedSLO),
+		},
+	}
+	for _, markdownTest := range tests {
+		t.Run(markdownTest.name, func(t *testing.T) {
+			handler := test.NewCombinedURLHandler(t, templateFile)
+			handler.AddExactTemplate(
+				dynatrace.DashboardsPath+"/"+testDashboardID,
+				&data{
+					Markdown: markdownTest.markdown,
+				},
+			)
+			handler.AddExactFile(dynatrace.SLOPath+"/7d07efde-b714-3e6e-ad95-08490e2540c4?from=1609459200000&timeFrame=GTF&to=1609545600000", "./testdata/dashboards/slo_tiles/passing_slo/slo_7d07efde-b714-3e6e-ad95-08490e2540c4.json")
+
+			rClient := &uploadErrorResourceClientMock{t: t}
+			runAndAssertThatDashboardTestIsCorrect(t, testDataExplorerGetSLIEventData, handler, rClient, getSLIFinishedEventSuccessAssertionsFunc, assertionFunc)
+
+			assert.EqualValues(t, rClient.uploadedSLOs, markdownTest.expectedSLO)
+		})
+	}
+}
+
+func createSLO(totalPass string, totalWarning string, compareWith string, includeWithScore string, numberOfResults int, aggregateFunc string, slo *keptnapi.SLO) *keptnapi.ServiceLevelObjectives {
+	return &keptnapi.ServiceLevelObjectives{
+		Comparison: &keptnapi.SLOComparison{
+			CompareWith:               compareWith,
+			IncludeResultWithScore:    includeWithScore,
+			NumberOfComparisonResults: numberOfResults,
+			AggregateFunction:         aggregateFunc,
+		},
+		TotalScore: &keptnapi.SLOScore{
+			Pass:    totalPass,
+			Warning: totalWarning,
+		},
+		Objectives: []*keptnapi.SLO{slo},
+	}
+}
+
+// TestRetrieveMetricsFromDashboard_MarkdownParsingErrors test lots of markdown tiles with errors in the SLO definition.
+// This will result in a failing SLIResult, as this is not allowed.
+func TestRetrieveMetricsFromDashboard_MarkdownParsingErrors(t *testing.T) {
+	const templateFile = "./testdata/dashboards/markdown/markdown-tile-parsing-errors-template.json"
+
+	tests := []struct {
+		name           string
+		markdown       string
+		assertionsFunc func(*testing.T, *keptnv2.SLIResult)
+	}{
+		{
+			name:           "unknown compare with score function",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=warn;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.withscore", "warn"),
+		},
+		{
+			name:           "unknown compare function, p97",
+			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=8;KQG.Compare.Function=p97",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.function", "p97"),
+		},
+		{
+			name:           "wrong number of results, 0",
+			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=0;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "0"),
+		},
+		{
+			name:           "wrong number of results, decimal",
+			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7.5;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "7.5"),
+		},
+		{
+			name:           "wrong number of results, string",
+			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=three;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "three"),
+		},
+		{
+			name:           "duplicate total pass",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Pass=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.pass", "duplicate key"),
+		},
+		{
+			name:           "duplicate total warning",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Warning=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.warning", "duplicate key"),
+		},
+		{
+			name:           "duplicate total compare with score",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.WithScore=all",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.withscore", "duplicate key"),
+		},
+		{
+			name:           "duplicate compare results",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Results=1",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "duplicate key"),
+		},
+		{
+			name:           "duplicate total compare function",
+			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Function=p90",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.function", "duplicate key"),
+		},
+		{
+			name:           "invalid value for total pass",
+			markdown:       "KQG.Total.Pass=96Pct",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.pass", "96Pct"),
+		},
+		{
+			name:           "invalid value for total warning",
+			markdown:       "KQG.Total.Warning=OneHundred",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.warning", "OneHundred"),
+		},
+		{
+			name:     "multiple problems - one for each",
+			markdown: "KQG.Total.Pass=96Pct;KQG.Total.Warning=OneHundred;KQG.Compare.WithScore=passing;KQG.Compare.Results=7.5;KQG.Compare.Function=p97;",
+			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric",
+				"kqg.total.pass", "96Pct",
+				"kqg.total.warning", "OneHundred",
+				"kqg.compare.withscore", "passing",
+				"kqg.compare.function", "p97",
+				"kqg.compare.results", "7.5"),
+		},
+	}
+	for _, markdownTest := range tests {
+		t.Run(markdownTest.name, func(t *testing.T) {
+			handler := test.NewTemplatingPayloadBasedURLHandler(t, templateFile)
+			handler.AddExact(
+				dynatrace.DashboardsPath+"/"+testDashboardID,
+				&data{
+					Markdown: markdownTest.markdown,
+				},
+			)
+
+			rClient := &uploadErrorResourceClientMock{t: t}
+			runAndAssertThatDashboardTestIsCorrect(t, testDataExplorerGetSLIEventData, handler, rClient, getSLIFinishedEventFailureAssertionsFunc, markdownTest.assertionsFunc)
+		})
+	}
+}

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
+	"github.com/keptn-contrib/dynatrace-service/internal/sli/dashboard"
 	"github.com/keptn-contrib/dynatrace-service/internal/test"
 )
 
@@ -19,10 +20,12 @@ type data struct {
 // there is one SLO tile as well to have a fully working example where SLOs would be stored as well
 func TestRetrieveMetricsFromDashboard_MarkdownParsingWorks(t *testing.T) {
 	const templateFile = "./testdata/dashboards/markdown/markdown-tile-parsing-single-sli-template.json"
-	assertionFunc := createSuccessfulSLIResultAssertionsFunc("Static_SLO_-_Pass", 95)
+	const sliName = "Static_SLO_-_Pass"
+
+	assertionFunc := createSuccessfulSLIResultAssertionsFunc(sliName, 95)
 
 	expectedSLO := &keptnapi.SLO{
-		SLI:     "Static_SLO_-_Pass",
+		SLI:     sliName,
 		Pass:    []*keptnapi.SLOCriteria{{Criteria: []string{">=90.000000"}}},
 		Warning: []*keptnapi.SLOCriteria{{Criteria: []string{">=75.000000"}}},
 		Weight:  1,
@@ -37,77 +40,77 @@ func TestRetrieveMetricsFromDashboard_MarkdownParsingWorks(t *testing.T) {
 		{
 			name:        "only defaults",
 			markdown:    "just some information here, that does not add any configuration",
-			expectedSLO: createSLO("90%", "75%", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90%", "75%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "total pass, rest is defaults",
 			markdown:    "KQG.Total.Pass=91%;",
-			expectedSLO: createSLO("91%", "75%", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("91%", "75%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "total warning, rest is defaults",
 			markdown:    "KQG.Total.Warning=76%;",
-			expectedSLO: createSLO("90%", "76%", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90%", "76%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "include with, rest is defaults",
 			markdown:    "KQG.Compare.WithScore=all;",
-			expectedSLO: createSLO("90%", "75%", "single_result", "all", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90%", "75%", dashboard.CompareResultsSingle, dashboard.CompareWithScoreAll, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "number of results, rest is defaults",
 			markdown:    "KQG.Compare.Results=2;",
-			expectedSLO: createSLO("90%", "75%", "several_results", "pass", 2, "avg", expectedSLO),
+			expectedSLO: createSLO("90%", "75%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 2, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "aggregate func, rest is defaults",
 			markdown:    "KQG.Compare.Function=p95;",
-			expectedSLO: createSLO("90%", "75%", "single_result", "pass", 1, "p95", expectedSLO),
+			expectedSLO: createSLO("90%", "75%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionP95, expectedSLO),
 		},
 		{
 			name:        "single result, without percent sign",
 			markdown:    "KQG.Total.Pass=90;KQG.Total.Warning=70;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
-			expectedSLO: createSLO("90", "70", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90", "70", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "single result, without percent sign, with decimals",
 			markdown:    "KQG.Total.Pass=90.84;KQG.Total.Warning=70.22;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
-			expectedSLO: createSLO("90.84", "70.22", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90.84", "70.22", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "single result, with percent sign, with decimals",
 			markdown:    "KQG.Total.Pass=90.84%;KQG.Total.Warning=70.22%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
-			expectedSLO: createSLO("90.84%", "70.22%", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90.84%", "70.22%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "single result",
 			markdown:    "KQG.Total.Pass=90%;KQG.Total.Warning=70%;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
-			expectedSLO: createSLO("90%", "70%", "single_result", "pass", 1, "avg", expectedSLO),
+			expectedSLO: createSLO("90%", "70%", dashboard.CompareResultsSingle, dashboard.CompareWithScorePass, 1, dashboard.CompareFunctionAvg, expectedSLO),
 		},
 		{
 			name:        "several results p50",
 			markdown:    "KQG.Total.Pass=91%;KQG.Total.Warning=71%;KQG.Compare.WithScore=pass;KQG.Compare.Results=2;KQG.Compare.Function=p50",
-			expectedSLO: createSLO("91%", "71%", "several_results", "pass", 2, "p50", expectedSLO),
+			expectedSLO: createSLO("91%", "71%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 2, dashboard.CompareFunctionP50, expectedSLO),
 		},
 		{
 			name:        "several results p90",
 			markdown:    "KQG.Total.Pass=92%;KQG.Total.Warning=72%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=p90",
-			expectedSLO: createSLO("92%", "72%", "several_results", "pass", 3, "p90", expectedSLO),
+			expectedSLO: createSLO("92%", "72%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 3, dashboard.CompareFunctionP90, expectedSLO),
 		},
 		{
 			name:        "several results p95",
 			markdown:    "KQG.Total.Pass=93%;KQG.Total.Warning=73%;KQG.Compare.WithScore=pass;KQG.Compare.Results=4;KQG.Compare.Function=p95",
-			expectedSLO: createSLO("93%", "73%", "several_results", "pass", 4, "p95", expectedSLO),
+			expectedSLO: createSLO("93%", "73%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 4, dashboard.CompareFunctionP95, expectedSLO),
 		},
 		{
 			name:        "several results p95 all",
 			markdown:    "KQG.Total.Pass=94%;KQG.Total.Warning=74%;KQG.Compare.WithScore=all;KQG.Compare.Results=5;KQG.Compare.Function=p95",
-			expectedSLO: createSLO("94%", "74%", "several_results", "all", 5, "p95", expectedSLO),
+			expectedSLO: createSLO("94%", "74%", dashboard.CompareResultsMultiple, dashboard.CompareWithScoreAll, 5, dashboard.CompareFunctionP95, expectedSLO),
 		},
 		{
 			name:        "several results p95 pass_or_warn",
 			markdown:    "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
-			expectedSLO: createSLO("95%", "75%", "several_results", "pass_or_warn", 6, "p95", expectedSLO),
+			expectedSLO: createSLO("95%", "75%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePassOrWarn, 6, dashboard.CompareFunctionP95, expectedSLO),
 		},
 	}
 	for _, markdownTest := range tests {
@@ -150,6 +153,9 @@ func createSLO(totalPass string, totalWarning string, compareWith string, includ
 func TestRetrieveMetricsFromDashboard_MarkdownParsingErrors(t *testing.T) {
 	const templateFile = "./testdata/dashboards/markdown/markdown-tile-parsing-errors-template.json"
 
+	const indicator = "no metric"
+	const duplicationError = "duplicate key"
+
 	tests := []struct {
 		name           string
 		markdown       string
@@ -158,72 +164,72 @@ func TestRetrieveMetricsFromDashboard_MarkdownParsingErrors(t *testing.T) {
 		{
 			name:           "unknown compare with score function",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=warn;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.withscore", "warn"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareWithScore, "warn"),
 		},
 		{
 			name:           "unknown compare function, p97",
 			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=8;KQG.Compare.Function=p97",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.function", "p97"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareFunction, "p97"),
 		},
 		{
 			name:           "wrong number of results, 0",
 			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=0;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "0"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareResults, "0"),
 		},
 		{
 			name:           "wrong number of results, decimal",
 			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7.5;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "7.5"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareResults, "7.5"),
 		},
 		{
 			name:           "wrong number of results, string",
 			markdown:       "KQG.Total.Pass=97%;KQG.Total.Warning=77%;KQG.Compare.WithScore=pass;KQG.Compare.Results=three;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "three"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareResults, "three"),
 		},
 		{
 			name:           "duplicate total pass",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Pass=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.pass", "duplicate key"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.TotalPass, duplicationError),
 		},
 		{
 			name:           "duplicate total warning",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Total.Warning=96%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.warning", "duplicate key"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.TotalWarning, duplicationError),
 		},
 		{
 			name:           "duplicate total compare with score",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.WithScore=all",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.withscore", "duplicate key"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareWithScore, duplicationError),
 		},
 		{
 			name:           "duplicate compare results",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Results=1",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.results", "duplicate key"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareResults, duplicationError),
 		},
 		{
 			name:           "duplicate total compare function",
 			markdown:       "KQG.Total.Pass=96%;KQG.Total.Warning=76%;KQG.Compare.WithScore=pass;KQG.Compare.Results=7;KQG.Compare.Function=p95;KQG.Compare.Function=p90",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.compare.function", "duplicate key"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.CompareFunction, duplicationError),
 		},
 		{
 			name:           "invalid value for total pass",
 			markdown:       "KQG.Total.Pass=96Pct",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.pass", "96Pct"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.TotalPass, "96Pct"),
 		},
 		{
 			name:           "invalid value for total warning",
 			markdown:       "KQG.Total.Warning=OneHundred",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric", "kqg.total.warning", "OneHundred"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator, dashboard.TotalWarning, "OneHundred"),
 		},
 		{
 			name:     "multiple problems - one for each",
 			markdown: "KQG.Total.Pass=96Pct;KQG.Total.Warning=OneHundred;KQG.Compare.WithScore=passing;KQG.Compare.Results=7.5;KQG.Compare.Function=p97;",
-			assertionsFunc: createFailedSLIResultAssertionsFunc("no metric",
-				"kqg.total.pass", "96Pct",
-				"kqg.total.warning", "OneHundred",
-				"kqg.compare.withscore", "passing",
-				"kqg.compare.function", "p97",
-				"kqg.compare.results", "7.5"),
+			assertionsFunc: createFailedSLIResultAssertionsFunc(indicator,
+				dashboard.TotalPass, "96Pct",
+				dashboard.TotalWarning, "OneHundred",
+				dashboard.CompareWithScore, "passing",
+				dashboard.CompareFunction, "p97",
+				dashboard.CompareResults, "7.5"),
 		},
 	}
 	for _, markdownTest := range tests {

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
@@ -40,6 +40,31 @@ func TestRetrieveMetricsFromDashboard_MarkdownParsingWorks(t *testing.T) {
 			expectedSLO: createSLO("90%", "75%", "single_result", "pass", 1, "avg", expectedSLO),
 		},
 		{
+			name:        "total pass, rest is defaults",
+			markdown:    "KQG.Total.Pass=91%;",
+			expectedSLO: createSLO("91%", "75%", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "total warning, rest is defaults",
+			markdown:    "KQG.Total.Warning=76%;",
+			expectedSLO: createSLO("90%", "76%", "single_result", "pass", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "include with, rest is defaults",
+			markdown:    "KQG.Compare.WithScore=all;",
+			expectedSLO: createSLO("90%", "75%", "single_result", "all", 1, "avg", expectedSLO),
+		},
+		{
+			name:        "number of results, rest is defaults",
+			markdown:    "KQG.Compare.Results=2;",
+			expectedSLO: createSLO("90%", "75%", "several_results", "pass", 2, "avg", expectedSLO),
+		},
+		{
+			name:        "aggregate func, rest is defaults",
+			markdown:    "KQG.Compare.Function=p95;",
+			expectedSLO: createSLO("90%", "75%", "single_result", "pass", 1, "p95", expectedSLO),
+		},
+		{
 			name:        "single result, without percent sign",
 			markdown:    "KQG.Total.Pass=90;KQG.Total.Warning=70;KQG.Compare.WithScore=pass;KQG.Compare.Results=1;KQG.Compare.Function=avg",
 			expectedSLO: createSLO("90", "70", "single_result", "pass", 1, "avg", expectedSLO),

--- a/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-errors-multiple-tiles-template.json
+++ b/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-errors-multiple-tiles-template.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      6
+    ],
+    "clusterVersion": "1.242.2.20220506-040755"
+  },
+  "id": "c809e28a-4b83-4d42-ba61-f9df2f0b9122",
+  "dashboardMetadata": {
+    "name": "data-explorer-tile-title-parsing-errors",
+    "shared": false,
+    "owner": "somebody",
+    "popularity": 8
+  },
+  "tiles": [
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 1178,
+        "height": 38
+      },
+      "tileFilter": {},
+      "markdown": "{{.MarkdownTileOne}}"
+    },
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 60,
+        "left": 0,
+        "width": 1178,
+        "height": 38
+      },
+      "tileFilter": {},
+      "markdown": "{{.MarkdownTileTwo}}"
+    }
+  ]
+}

--- a/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-errors-template.json
+++ b/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-errors-template.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      6
+    ],
+    "clusterVersion": "1.242.2.20220506-040755"
+  },
+  "id": "c809e28a-4b83-4d42-ba61-f9df2f0b9122",
+  "dashboardMetadata": {
+    "name": "data-explorer-tile-title-parsing-errors",
+    "shared": false,
+    "owner": "somebody",
+    "popularity": 8
+  },
+  "tiles": [
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 1178,
+        "height": 38
+      },
+      "tileFilter": {},
+      "markdown": "{{.Markdown}}"
+    }
+  ]
+}

--- a/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-single-sli-template.json
+++ b/internal/sli/testdata/dashboards/markdown/markdown-tile-parsing-single-sli-template.json
@@ -1,0 +1,47 @@
+{
+  "metadata": {
+    "configurationVersions": [
+      6
+    ],
+    "clusterVersion": "1.242.2.20220506-040755"
+  },
+  "id": "c809e28a-4b83-4d42-ba61-f9df2f0b9122",
+  "dashboardMetadata": {
+    "name": "data-explorer-tile-title-parsing-errors",
+    "shared": false,
+    "owner": "somebody",
+    "popularity": 8
+  },
+  "tiles": [
+    {
+      "name": "Markdown",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 0,
+        "left": 0,
+        "width": 1178,
+        "height": 38
+      },
+      "tileFilter": {},
+      "markdown": "{{.Markdown}}"
+    },
+    {
+      "name": "Service-level objective",
+      "tileType": "SLO",
+      "configured": true,
+      "bounds": {
+        "top": 38,
+        "left": 0,
+        "width": 304,
+        "height": 152
+      },
+      "tileFilter": {
+        "timeframe": "-72h to now"
+      },
+      "assignedEntities": [
+        "7d07efde-b714-3e6e-ad95-08490e2540c4"
+      ]
+    }
+  ]
+}

--- a/internal/test/combined_url_handler.go
+++ b/internal/test/combined_url_handler.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"net/http"
+	"testing"
+)
+
+type CombinedURLHandler struct {
+	t                 *testing.T
+	useFileHandler    map[string]bool
+	fileHandler       *FileBasedURLHandler
+	templatingHandler *TemplatingPayloadBasedURLHandler
+}
+
+func NewCombinedURLHandler(t *testing.T, templateFile string) *CombinedURLHandler {
+	return &CombinedURLHandler{
+		t:                 t,
+		useFileHandler:    make(map[string]bool),
+		fileHandler:       NewFileBasedURLHandler(t),
+		templatingHandler: NewTemplatingPayloadBasedURLHandler(t, templateFile),
+	}
+}
+
+func (h *CombinedURLHandler) AddExactFile(url string, fileName string) {
+	_, alreadyThere := h.useFileHandler[url]
+	if alreadyThere {
+		h.t.Fatalf("%s has been already stored, check your test configuration", url)
+	}
+
+	h.useFileHandler[url] = true
+	h.fileHandler.AddExact(url, fileName)
+}
+
+func (h *CombinedURLHandler) AddExactTemplate(url string, templatingData interface{}) {
+	_, alreadyThere := h.useFileHandler[url]
+	if alreadyThere {
+		h.t.Fatalf("%s has been already stored, check your test configuration", url)
+	}
+
+	h.useFileHandler[url] = false
+	h.templatingHandler.AddExact(url, templatingData)
+}
+
+func (h *CombinedURLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url := r.URL.String()
+	if h.useFileHandler[url] {
+		h.fileHandler.ServeHTTP(w, r)
+		return
+	}
+
+	h.templatingHandler.ServeHTTP(w, r)
+}
+
+/*
+/api/v2/slo/7d07efde-b714-3e6e-ad95-08490e2540c4?from=1631862000000&timeFrame=GTF&to=1631865600000
+
+/api/v2/slo/7d07efde-b714-3e6e-ad95-08490e2540c4?from=1609459200000&timeFrame=GTF&to=1609545600000
+
+*/


### PR DESCRIPTION
closes #629 

in case an error occurs while parsing the configuration contained in a **markdown** tile and error will be returned and no evaluation of SLIs will be done.

### What is considered an error?
* duplicate entries for any of the *keys*: `KQG.Total.Pass`, `KQG.Total.Warning`, `KQG.Compare.WithScore`, `KQG.Compare.Results` and `KQG.Compare.Function`
* `KQG.Total.Pass`, `KQG.Total.Warning`: any value that is not a non-negative decimal including an optional `%`. So basically anything that does not match: `^(\d+|\d+\.\d+)([%]?)$`
* `KQG.Compare.WithScore`: any value other than `pass`, `all`, `pass_or_warn`
* `KQG.Compare.Results`: any not integral value as well as integers that are less than `1`
* `KQG.Compare.Function`: any value other than `avg`, `p50`, `p90`, `p95`
