### PR TITLE
fix: Data Explorer tiles using a management zone should produce an error if no entity type can be determined

### DIFF
--- a/internal/sli/dashboard/data_explorer_tile_processing.go
+++ b/internal/sli/dashboard/data_explorer_tile_processing.go
@@ -138,13 +138,11 @@ func (p *DataExplorerTileProcessing) generateMetricQueryFromDataExplorerQuery(ct
 	// optionally add management zone filter to entity selector filter
 	managementZoneFilterString := managementZoneFilter.ForEntitySelector()
 	if managementZoneFilterString != "" {
-		if processedFilter.entitySelectorFilter == "" {
-			if len(metricDefinition.EntityType) == 0 {
-				return nil, fmt.Errorf("metric %s has no entity type", metricDefinition.MetricID)
-			}
-			processedFilter.entitySelectorFilter = fmt.Sprintf("type(%s)", metricDefinition.EntityType[0])
+		entitySelectorFilter, err := ensureEntitySelectorFilter(processedFilter.entitySelectorFilter, metricDefinition)
+		if err != nil {
+			return nil, err
 		}
-		processedFilter.entitySelectorFilter = processedFilter.entitySelectorFilter + managementZoneFilterString
+		processedFilter.entitySelectorFilter = entitySelectorFilter + managementZoneFilterString
 	}
 
 	// NOTE: add :names so we also get the names of the dimensions and not just the entities. This means we get two values for each dimension
@@ -164,6 +162,18 @@ func (p *DataExplorerTileProcessing) generateMetricQueryFromDataExplorerQuery(ct
 		metricSelectorTargetSnippet: processedFilter.metricSelectorTargetSnippet,
 	}, nil
 
+}
+
+func ensureEntitySelectorFilter(existingEntitySelectorFilter string, metricDefinition *dynatrace.MetricDefinition) (string, error) {
+	if existingEntitySelectorFilter != "" {
+		return existingEntitySelectorFilter, nil
+	}
+
+	if len(metricDefinition.EntityType) == 0 {
+		return "", fmt.Errorf("metric %s has no entity type", metricDefinition.MetricID)
+	}
+
+	return fmt.Sprintf("type(%s)", metricDefinition.EntityType[0]), nil
 }
 
 type processedFilterComponents struct {

--- a/internal/sli/dashboard/data_explorer_tile_processing.go
+++ b/internal/sli/dashboard/data_explorer_tile_processing.go
@@ -139,6 +139,9 @@ func (p *DataExplorerTileProcessing) generateMetricQueryFromDataExplorerQuery(ct
 	managementZoneFilterString := managementZoneFilter.ForEntitySelector()
 	if managementZoneFilterString != "" {
 		if processedFilter.entitySelectorFilter == "" {
+			if len(metricDefinition.EntityType) == 0 {
+				return nil, fmt.Errorf("metric %s has no entity type", metricDefinition.MetricID)
+			}
 			processedFilter.entitySelectorFilter = fmt.Sprintf("type(%s)", metricDefinition.EntityType[0])
 		}
 		processedFilter.entitySelectorFilter = processedFilter.entitySelectorFilter + managementZoneFilterString

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
@@ -528,3 +528,20 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_ServiceTag_Filter_WithCust
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testDataExplorerGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, uploadedSLIsAssertionsFunc, sliResultsAssertionsFuncs...)
 }
+
+// TestRetrieveMetricsFromDashboardDataExplorerTile_NoEntityType tests that an error is produced for data explorer tiles with no obvious entity type.
+// This currently causes a panic.
+func TestRetrieveMetricsFromDashboardDataExplorerTile_NoEntityType(t *testing.T) {
+	const testDataFolder = "./testdata/dashboards/data_explorer/no_entity_type/"
+
+	handler := test.NewFileBasedURLHandler(t)
+	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, testDataFolder+"dashboard.json")
+	handler.AddExact(dynatrace.MetricsPath+"/builtin:security.securityProblem.open.managementZone", testDataFolder+"metrics_builtin_security_securityProblem_open_managementZone.json")
+
+	sliResultsAssertionsFuncs := []func(t *testing.T, actual *keptnv2.SLIResult){}
+
+	uploadedSLIsAssertionsFunc := func(t *testing.T, actual *dynatrace.SLI) {
+	}
+
+	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testDataExplorerGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, uploadedSLIsAssertionsFunc, sliResultsAssertionsFuncs...)
+}

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
@@ -529,19 +529,15 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_ServiceTag_Filter_WithCust
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testDataExplorerGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, uploadedSLIsAssertionsFunc, sliResultsAssertionsFuncs...)
 }
 
-// TestRetrieveMetricsFromDashboardDataExplorerTile_NoEntityType tests that an error is produced for data explorer tiles with no obvious entity type.
-// This currently causes a panic.
-func TestRetrieveMetricsFromDashboardDataExplorerTile_NoEntityType(t *testing.T) {
+// TestRetrieveMetricsFromDashboardDataExplorerTile_ManagementZoneWithNoEntityType tests that an error is produced for data explorer tiles with a management zone and no obvious entity type.
+// This is will result in a SLIResult with failure, as this is not allowed.
+func TestRetrieveMetricsFromDashboardDataExplorerTile_ManagementZoneWithNoEntityType(t *testing.T) {
 	const testDataFolder = "./testdata/dashboards/data_explorer/no_entity_type/"
 
 	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, testDataFolder+"dashboard.json")
 	handler.AddExact(dynatrace.MetricsPath+"/builtin:security.securityProblem.open.managementZone", testDataFolder+"metrics_builtin_security_securityProblem_open_managementZone.json")
 
-	sliResultsAssertionsFuncs := []func(t *testing.T, actual *keptnv2.SLIResult){}
-
-	uploadedSLIsAssertionsFunc := func(t *testing.T, actual *dynatrace.SLI) {
-	}
-
-	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testDataExplorerGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, uploadedSLIsAssertionsFunc, sliResultsAssertionsFuncs...)
+	rClient := &uploadErrorResourceClientMock{t: t}
+	runAndAssertThatDashboardTestIsCorrect(t, testDataExplorerGetSLIEventData, handler, rClient, getSLIFinishedEventFailureAssertionsFunc, createFailedSLIResultAssertionsFunc("vulnerabilities_high", "has no entity type"))
 }

--- a/internal/sli/testdata/dashboards/data_explorer/no_entity_type/dashboard.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_entity_type/dashboard.json
@@ -1,0 +1,61 @@
+{
+    "id": "12345678-1111-4444-8888-123456789012",
+    "dashboardMetadata": {
+      "name": "test",
+      "shared": false,
+      "owner": "",
+      "dashboardFilter": {
+        "managementZone": {          
+          "id": "-1234567890123456789",
+          "name": "mz-1"
+        }
+      }
+    },
+    "tiles": [
+      {
+        "name": "HIGH Vulnerabilities;sli=vulnerabilities_high;pass=<=+0,<1;weight=5;key=true",
+        "tileType": "DATA_EXPLORER",
+        "configured": true,
+        "bounds": {
+          "top": 38,
+          "left": 608,
+          "width": 304,
+          "height": 304
+        },
+        "tileFilter": {},
+        "customName": "Data explorer results",
+        "queries": [
+          {
+            "id": "A",
+            "metric": "builtin:security.securityProblem.open.managementZone",
+            "spaceAggregation": "SUM",
+            "timeAggregation": "DEFAULT",
+            "splitBy": [
+              "Risk Level"
+            ],
+            "sortBy": "DESC",
+            "filterBy": {
+              "filterOperator": "AND",
+              "nestedFilters": [
+                {
+                  "filter": "Risk Level",
+                  "filterType": "DIMENSION",
+                  "filterOperator": "OR",
+                  "nestedFilters": [],
+                  "criteria": [
+                    {
+                      "value": "HIGH",
+                      "evaluator": "EQ"
+                    }
+                  ]
+                }
+              ],
+              "criteria": []
+            },
+            "limit": 100,
+            "enabled": true
+          }
+        ]
+      }
+    ]
+  }

--- a/internal/sli/testdata/dashboards/data_explorer/no_entity_type/metrics_builtin_security_securityProblem_open_managementZone.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_entity_type/metrics_builtin_security_securityProblem_open_managementZone.json
@@ -1,0 +1,79 @@
+{
+  "metricId": "builtin:security.securityProblem.open.managementZone",
+  "displayName": "Open Security Problems (split by Management Zone)",
+  "description": "",
+  "unit": "Count",
+  "dduBillable": false,
+  "created": 0,
+  "lastWritten": 1652174798489,
+  "entityType": [],
+  "aggregationTypes": [
+    "auto",
+    "avg",
+    "max",
+    "min"
+  ],
+  "transformations": [
+    "filter",
+    "fold",
+    "limit",
+    "merge",
+    "names",
+    "parents",
+    "timeshift",
+    "sort",
+    "last",
+    "splitBy",
+    "lastReal",
+    "setUnit"
+  ],
+  "defaultAggregation": {
+    "type": "avg"
+  },
+  "dimensionDefinitions": [
+    {
+      "key": "Risk Level",
+      "name": null,
+      "displayName": "Risk Level",
+      "index": null,
+      "type": "STRING"
+    },
+    {
+      "key": "Type",
+      "name": null,
+      "displayName": "Type",
+      "index": null,
+      "type": "STRING"
+    },
+    {
+      "key": "dt.management_zone",
+      "name": null,
+      "displayName": "dt.management_zone",
+      "index": null,
+      "type": "STRING"
+    }
+  ],
+  "tags": [],
+  "metricValueType": {
+    "type": "unknown"
+  },
+  "scalar": false,
+  "resolutionInfSupported": false,
+  "dimensionCardinalities": [
+    {
+      "key": "Risk Level",
+      "estimate": 4,
+      "relative": 1.5037593984962405
+    },
+    {
+      "key": "Type",
+      "estimate": 2,
+      "relative": 0.7518796992481203
+    },
+    {
+      "key": "dt.management_zone",
+      "estimate": 33,
+      "relative": 12.406015037593985
+    }
+  ]
+}


### PR DESCRIPTION
Closes #801 