### PR TITLE
fix: Move `GetSLIs()` and `GetShipyard()` to `keptn.ConfigClient`

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -51,5 +51,5 @@ func NewMarshalJSONError(context string, cause error) *MarshalError {
 }
 
 func (e *MarshalError) Error() string {
-	return fmt.Sprintf("could not %s %s to %s (%v)", e.marshalType, e.context, e.dataType, e.cause)
+	return fmt.Sprintf("could not %s %s %s: %v", e.marshalType, e.context, e.dataType, e.cause)
 }

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -53,3 +53,8 @@ func NewMarshalJSONError(context string, cause error) *MarshalError {
 func (e *MarshalError) Error() string {
 	return fmt.Sprintf("could not %s %s %s: %v", e.marshalType, e.context, e.dataType, e.cause)
 }
+
+// Unwrap returns the cause of the MarshalError.
+func (e *MarshalError) Unwrap() error {
+	return e.cause
+}

--- a/internal/config/dynatrace_config_getter.go
+++ b/internal/config/dynatrace_config_getter.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
@@ -36,7 +34,7 @@ func (d *DynatraceConfigGetter) GetDynatraceConfig(event adapter.EventContentAda
 	// unmarshal the file
 	dynatraceConfig, err := parseDynatraceConfigYAML(fileContent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse dynatrace config file found for service %s in stage %s in project %s: %s", event.GetService(), event.GetStage(), event.GetProject(), err.Error())
+		return nil, err
 	}
 
 	dynatraceConfig = replacePlaceholdersInDynatraceConfig(dynatraceConfig, event)
@@ -101,7 +99,7 @@ func parseDynatraceConfigYAML(input string) (*DynatraceConfig, error) {
 	dynatraceConfig := NewDynatraceConfigWithDefaults()
 	err := yaml.Unmarshal([]byte(input), dynatraceConfig)
 	if err != nil {
-		return nil, err
+		return nil, common.NewUnmarshalYAMLError("Dynatrace config", err)
 	}
 
 	return dynatraceConfig, nil

--- a/internal/event_handler/handler.go
+++ b/internal/event_handler/handler.go
@@ -84,7 +84,7 @@ func getEventHandler(ctx context.Context, event cloudevents.Event, clientFactory
 
 	switch aType := keptnEvent.(type) {
 	case *monitoring.ConfigureMonitoringAdapter:
-		return monitoring.NewConfigureMonitoringEventHandler(keptnEvent.(*monitoring.ConfigureMonitoringAdapter), dtClient, kClient, keptn.NewConfigClient(clientFactory.CreateResourceClient()), clientFactory.CreateServiceClient(), keptn.NewDefaultCredentialsChecker()), nil
+		return monitoring.NewConfigureMonitoringEventHandler(keptnEvent.(*monitoring.ConfigureMonitoringAdapter), dtClient, kClient, keptn.NewConfigClient(clientFactory.CreateResourceClient()), keptn.NewConfigClient(clientFactory.CreateResourceClient()), clientFactory.CreateServiceClient(), keptn.NewDefaultCredentialsChecker()), nil
 	case *problem.ProblemAdapter:
 		return problem.NewProblemEventHandler(keptnEvent.(*problem.ProblemAdapter), kClient), nil
 	case *action.ActionTriggeredAdapter:

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -201,7 +201,7 @@ func readSLIsFromResource(resource string) (map[string]string, error) {
 	sliConfig := keptnapi.SLIConfig{}
 	err := yaml.Unmarshal([]byte(resource), &sliConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse SLI YAML: %w", err)
 	}
 
 	if len(sliConfig.Indicators) == 0 {

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -128,7 +128,7 @@ type sliMap map[string]string
 
 func (m sliMap) insertOrUpdateMany(x map[string]string) {
 	for key, value := range x {
-		map[string]string(m)[key] = value
+		m[key] = value
 	}
 }
 

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -9,6 +9,7 @@ import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"gopkg.in/yaml.v2"
 
+	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 )
 
@@ -109,14 +110,6 @@ func (rc *ConfigClient) GetDynatraceConfig(project string, stage string, service
 
 // GetShipyard returns the shipyard definition of a project.
 func (rc *ConfigClient) GetShipyard(project string) (*keptnv2.Shipyard, error) {
-	shipyard, err := rc.getShipyard(project)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve shipyard for project %s: %w", project, err)
-	}
-	return shipyard, nil
-}
-
-func (rc *ConfigClient) getShipyard(project string) (*keptnv2.Shipyard, error) {
 	shipyardResource, err := rc.client.GetProjectResource(project, shipyardFilename)
 	if err != nil {
 		return nil, err
@@ -125,7 +118,7 @@ func (rc *ConfigClient) getShipyard(project string) (*keptnv2.Shipyard, error) {
 	shipyard := keptnv2.Shipyard{}
 	err = yaml.Unmarshal([]byte(shipyardResource), &shipyard)
 	if err != nil {
-		return nil, err
+		return nil, common.NewUnmarshalYAMLError("shipyard", err)
 	}
 
 	return &shipyard, nil
@@ -201,7 +194,7 @@ func readSLIsFromResource(resource string) (map[string]string, error) {
 	sliConfig := keptnapi.SLIConfig{}
 	err := yaml.Unmarshal([]byte(resource), &sliConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse SLI YAML: %w", err)
+		return nil, common.NewUnmarshalYAMLError("SLIs", err)
 	}
 
 	if len(sliConfig.Indicators) == 0 {

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -127,13 +127,22 @@ func (rc *ConfigClient) getShipyard(project string) (*keptnv2.Shipyard, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &shipyard, nil
+}
+
+type sliMap map[string]string
+
+func (m *sliMap) insertOrUpdateMany(x map[string]string) {
+	for key, value := range x {
+		map[string]string(*m)[key] = value
+	}
 }
 
 // GetSLIs gets the SLIs stored for the specified project, stage and service.
 // First, the configuration of project-level is retrieved, which is then overridden by configuration on stage level, and then overridden by configuration on service level.
 func (rc *ConfigClient) GetSLIs(project string, stage string, service string) (map[string]string, error) {
-	slis := make(map[string]string)
+	slis := make(sliMap)
 
 	// try to get SLI config from project
 	if project != "" {
@@ -142,9 +151,7 @@ func (rc *ConfigClient) GetSLIs(project string, stage string, service string) (m
 			return nil, err
 		}
 
-		for key, value := range projectSLIs {
-			slis[key] = value
-		}
+		slis.insertOrUpdateMany(projectSLIs)
 	}
 
 	// try to get SLI config from stage
@@ -154,9 +161,7 @@ func (rc *ConfigClient) GetSLIs(project string, stage string, service string) (m
 			return nil, err
 		}
 
-		for key, value := range stageSLIs {
-			slis[key] = value
-		}
+		slis.insertOrUpdateMany(stageSLIs)
 	}
 
 	// try to get SLI config from service
@@ -166,9 +171,7 @@ func (rc *ConfigClient) GetSLIs(project string, stage string, service string) (m
 			return nil, err
 		}
 
-		for key, value := range serviceSLIs {
-			slis[key] = value
-		}
+		slis.insertOrUpdateMany(serviceSLIs)
 	}
 
 	return slis, nil

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -14,7 +14,6 @@ import (
 
 // SLIAndSLOReaderInterface provides functionality for getting SLIs and SLOs.
 type SLIAndSLOReaderInterface interface {
-
 	// GetSLIs gets the SLIs stored for the specified project, stage and service.
 	// First, the configuration of project-level is retrieved, which is then overridden by configuration on stage level, and then overridden by configuration on service level.
 	GetSLIs(project string, stage string, service string) (map[string]string, error)

--- a/internal/keptn/config_client.go
+++ b/internal/keptn/config_client.go
@@ -126,9 +126,9 @@ func (rc *ConfigClient) GetShipyard(project string) (*keptnv2.Shipyard, error) {
 
 type sliMap map[string]string
 
-func (m *sliMap) insertOrUpdateMany(x map[string]string) {
+func (m sliMap) insertOrUpdateMany(x map[string]string) {
 	for key, value := range x {
-		map[string]string(*m)[key] = value
+		map[string]string(m)[key] = value
 	}
 }
 

--- a/internal/keptn/config_client_test.go
+++ b/internal/keptn/config_client_test.go
@@ -60,7 +60,7 @@ func TestConfigClient_GetSLIsInvalidYAMLCausesError(t *testing.T) {
 	slis, err := rc.GetSLIs(testProject, testStage, testService)
 	assert.Nil(t, slis)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "could not unmarshal SLIs to YAML")
+	assert.Contains(t, err.Error(), "could not unmarshal SLIs YAML")
 }
 
 // TestConfigClient_GetSLIsRetrievalErrorCausesError tests that resource retrieval errors produce an error.

--- a/internal/keptn/config_client_test.go
+++ b/internal/keptn/config_client_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,8 +60,8 @@ func TestConfigClient_GetSLIsInvalidYAMLCausesError(t *testing.T) {
 			projectResource: getInvalidYAMLResource(t)})
 	slis, err := rc.GetSLIs(testProject, testStage, testService)
 	assert.Nil(t, slis)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "could not unmarshal SLIs YAML")
+	var marshalErr *common.MarshalError
+	assert.ErrorAs(t, err, &marshalErr)
 }
 
 // TestConfigClient_GetSLIsRetrievalErrorCausesError tests that resource retrieval errors produce an error.

--- a/internal/keptn/config_client_test.go
+++ b/internal/keptn/config_client_test.go
@@ -60,7 +60,7 @@ func TestConfigClient_GetSLIsInvalidYAMLCausesError(t *testing.T) {
 	slis, err := rc.GetSLIs(testProject, testStage, testService)
 	assert.Nil(t, slis)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse SLI YAML")
+	assert.Contains(t, err.Error(), "could not unmarshal SLIs to YAML")
 }
 
 // TestConfigClient_GetSLIsRetrievalErrorCausesError tests that resource retrieval errors produce an error.

--- a/internal/keptn/config_client_test.go
+++ b/internal/keptn/config_client_test.go
@@ -1,0 +1,201 @@
+package keptn
+
+import (
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testProject = "my-project"
+const testStage = "my-stage"
+const testService = "my-service"
+
+const testSLIName = "response_time"
+const testResponseTime90SLI = "metricSelector=builtin:service.response.time:splitBy():percentile(90)"
+const testResponseTime95SLI = "metricSelector=builtin:service.response.time:splitBy():percentile(95)"
+
+func TestConfigClient_GetSLIsNoneDefined(t *testing.T) {
+	rc := NewConfigClient(&mockResourceClient{t: t})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.Empty(t, slis)
+	assert.NoError(t, err)
+}
+
+func TestConfigClient_GetSLIsServiceOverridesStage(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			stageResource:   getResponseTime90Resource(t),
+			serviceResource: getResponseTime95Resource(t)})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.NoError(t, err)
+	if !assert.Len(t, slis, 1) {
+		return
+	}
+
+	if !assert.Contains(t, slis, testSLIName) {
+		return
+	}
+
+	assert.EqualValues(t, testResponseTime95SLI, slis[testSLIName])
+}
+
+func TestConfigClient_GetSLIsStageOverridesProject(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			projectResource: getResponseTime90Resource(t),
+			stageResource:   getResponseTime95Resource(t)})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.NoError(t, err)
+	if !assert.Len(t, slis, 1) {
+		return
+	}
+
+	if !assert.Contains(t, slis, testSLIName) {
+		return
+	}
+
+	assert.EqualValues(t, testResponseTime95SLI, slis[testSLIName])
+}
+
+func TestConfigClient_GetSLIsServiceOverridesProject(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			projectResource: getResponseTime90Resource(t),
+			serviceResource: getResponseTime95Resource(t)})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.NoError(t, err)
+	if !assert.Len(t, slis, 1) {
+		return
+	}
+
+	if !assert.Contains(t, slis, testSLIName) {
+		return
+	}
+
+	assert.EqualValues(t, testResponseTime95SLI, slis[testSLIName])
+}
+
+func TestConfigClient_GetSLIsInvalidYAMLCausesError(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			projectResource: getInvalidYAMLResource(t),
+			serviceResource: getResponseTime95Resource(t)})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.Nil(t, slis)
+	assert.Error(t, err)
+}
+
+func TestConfigClient_GetSLIsErrorCausesError(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			serviceResource: &mockResource{err: errors.New("Failed to connect")}})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.Nil(t, slis)
+	assert.Error(t, err)
+}
+
+func TestConfigClient_GetSLIsNoIndicatorsCausesError(t *testing.T) {
+	rc := NewConfigClient(
+		&mockResourceClient{
+			t:               t,
+			serviceResource: getNoIndicatorsResource(t)})
+	slis, err := rc.GetSLIs(testProject, testStage, testService)
+	assert.Nil(t, slis)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required field")
+}
+
+const testDataFolder = "./testdata/config_client/get_slis"
+
+func getNoIndicatorsResource(t *testing.T) *mockResource {
+	return &mockResource{resource: loadResource(t, testDataFolder+"/sli_no_indicators.yaml")}
+}
+
+func getInvalidYAMLResource(t *testing.T) *mockResource {
+	return &mockResource{resource: loadResource(t, testDataFolder+"/sli.invalid_yaml")}
+}
+
+func getResponseTime50Resource(t *testing.T) *mockResource {
+	return &mockResource{resource: loadResource(t, testDataFolder+"/sli_response_time_50.yaml")}
+}
+
+func getResponseTime90Resource(t *testing.T) *mockResource {
+	return &mockResource{resource: loadResource(t, testDataFolder+"/sli_response_time_90.yaml")}
+}
+
+func getResponseTime95Resource(t *testing.T) *mockResource {
+	return &mockResource{resource: loadResource(t, testDataFolder+"/sli_response_time_95.yaml")}
+}
+
+func loadResource(t *testing.T, filename string) string {
+	content, err := ioutil.ReadFile(filename)
+	assert.NoError(t, err)
+	return string(content)
+}
+
+type mockResource struct {
+	resource string
+	err      error
+}
+
+const testSLIResourceURI = "dynatrace/sli.yaml"
+
+type mockResourceClient struct {
+	t               *testing.T
+	projectResource *mockResource
+	stageResource   *mockResource
+	serviceResource *mockResource
+}
+
+func (rc *mockResourceClient) GetResource(project string, stage string, service string, resourceURI string) (string, error) {
+	rc.t.Fatalf("GetResource() should not be needed in this mock!")
+	return "", nil
+}
+
+func (rc *mockResourceClient) GetProjectResource(project string, resourceURI string) (string, error) {
+	assert.EqualValues(rc.t, testProject, project)
+	assert.EqualValues(rc.t, testSLIResourceURI, resourceURI)
+
+	if rc.projectResource == nil {
+		return "", &ResourceNotFoundError{project: project, uri: resourceURI}
+	}
+
+	return rc.projectResource.resource, rc.projectResource.err
+}
+
+func (rc *mockResourceClient) GetStageResource(project string, stage string, resourceURI string) (string, error) {
+	assert.EqualValues(rc.t, testProject, project)
+	assert.EqualValues(rc.t, testStage, stage)
+	assert.EqualValues(rc.t, testSLIResourceURI, resourceURI)
+
+	if rc.stageResource == nil {
+		return "", &ResourceNotFoundError{project: project, stage: stage, uri: resourceURI}
+	}
+
+	return rc.stageResource.resource, rc.stageResource.err
+}
+
+func (rc *mockResourceClient) GetServiceResource(project string, stage string, service string, resourceURI string) (string, error) {
+	assert.EqualValues(rc.t, testProject, project)
+	assert.EqualValues(rc.t, testStage, stage)
+	assert.EqualValues(rc.t, testService, service)
+	assert.EqualValues(rc.t, testSLIResourceURI, resourceURI)
+
+	if rc.serviceResource == nil {
+		return "", &ResourceNotFoundError{project: project, stage: stage, service: service, uri: resourceURI}
+	}
+
+	return rc.serviceResource.resource, rc.serviceResource.err
+}
+
+func (rc *mockResourceClient) UploadResource(contentToUpload []byte, remoteResourceURI string, project string, stage string, service string) error {
+	rc.t.Fatalf("UploadResource() should not be needed in this mock!")
+	return nil
+}

--- a/internal/keptn/config_client_test.go
+++ b/internal/keptn/config_client_test.go
@@ -1,6 +1,7 @@
 package keptn
 
 import (
+	"errors"
 	"io/ioutil"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestConfigClient_GetSLIsRetrievalErrorCausesError(t *testing.T) {
 	rc := NewConfigClient(
 		&mockResourceClient{
 			t:               t,
-			serviceResource: &mockResource{err: &ResourceRetrievalFailedError{ResourceError{uri: testSLIResourceURI, project: testProject, stage: testStage, service: testService}, "Connection error"}}})
+			serviceResource: &mockResource{err: &ResourceRetrievalFailedError{ResourceError{uri: testSLIResourceURI, project: testProject, stage: testStage, service: testService}, errors.New("Connection error")}}})
 	slis, err := rc.GetSLIs(testProject, testStage, testService)
 	assert.Nil(t, slis)
 	assert.Error(t, err)

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -70,7 +70,6 @@ func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string,
 
 type ClientInterface interface {
 	GetCustomQueries(project string, stage string, service string) (*CustomQueries, error)
-	GetShipyard() (*keptnv2.Shipyard, error)
 	SendCloudEvent(factory adapter.CloudEventFactoryInterface) error
 }
 
@@ -107,15 +106,6 @@ func (c *Client) GetCustomQueries(project string, stage string, service string) 
 	}
 
 	return &CustomQueries{values: customQueries}, nil
-}
-
-func (c *Client) GetShipyard() (*keptnv2.Shipyard, error) {
-	shipyard, err := c.client.GetShipyard()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve shipyard for project %s: %v", c.client.Event.GetProject(), err)
-	}
-
-	return shipyard, nil
 }
 
 func (c *Client) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -1,7 +1,6 @@
 package keptn
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -13,7 +12,6 @@ import (
 const sliResourceURI = "dynatrace/sli.yaml"
 
 type ClientInterface interface {
-	GetSLIs(project string, stage string, service string) (map[string]string, error)
 	SendCloudEvent(factory adapter.CloudEventFactoryInterface) error
 }
 
@@ -37,19 +35,6 @@ func NewDefaultClient(event event.Event) (*Client, error) {
 		return nil, fmt.Errorf("could not create default Keptn client: %v", err)
 	}
 	return NewClient(kClient), nil
-}
-
-func (c *Client) GetSLIs(project string, stage string, service string) (map[string]string, error) {
-	if c.client == nil {
-		return nil, errors.New("could not retrieve SLI config: no Keptn client initialized")
-	}
-
-	slis, err := c.client.GetSLIConfiguration(project, stage, service, sliResourceURI)
-	if err != nil {
-		return nil, err
-	}
-
-	return slis, nil
 }
 
 func (c *Client) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -12,64 +12,8 @@ import (
 
 const sliResourceURI = "dynatrace/sli.yaml"
 
-const Throughput = "throughput"
-const errorRate = "error_rate"
-const ResponseTimeP50 = "response_time_p50"
-const responseTimeP90 = "response_time_p90"
-const responseTimeP95 = "response_time_p95"
-
-type CustomQueries struct {
-	values map[string]string
-}
-
-func NewEmptyCustomQueries() *CustomQueries {
-	return &CustomQueries{
-		values: make(map[string]string),
-	}
-}
-
-func NewCustomQueries(values map[string]string) *CustomQueries {
-	return &CustomQueries{
-		values: values,
-	}
-}
-
-func (cq *CustomQueries) GetQueryByNameOrDefault(sliName string) (string, error) {
-	query, exists := cq.values[sliName]
-	if exists {
-		return query, nil
-	}
-
-	defaultQuery, err := getDefaultQuery(sliName)
-	if err != nil {
-		return "", err
-	}
-
-	return defaultQuery, nil
-}
-
-func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string, error) {
-	query, exists := cq.values[sliName]
-	if exists {
-		return query, nil
-	}
-
-	// there are custom SLIs defined, but we could not match it
-	if len(cq.values) != 0 {
-		return "", fmt.Errorf("SLI definition for '%s' was not found", sliName)
-	}
-
-	// no custom SLIs defined - so we fallback to using defaults
-	defaultQuery, err := getDefaultQuery(sliName)
-	if err != nil {
-		return "", err
-	}
-
-	return defaultQuery, nil
-}
-
 type ClientInterface interface {
-	GetCustomQueries(project string, stage string, service string) (*CustomQueries, error)
+	GetSLIs(project string, stage string, service string) (map[string]string, error)
 	SendCloudEvent(factory adapter.CloudEventFactoryInterface) error
 }
 
@@ -95,17 +39,17 @@ func NewDefaultClient(event event.Event) (*Client, error) {
 	return NewClient(kClient), nil
 }
 
-func (c *Client) GetCustomQueries(project string, stage string, service string) (*CustomQueries, error) {
+func (c *Client) GetSLIs(project string, stage string, service string) (map[string]string, error) {
 	if c.client == nil {
 		return nil, errors.New("could not retrieve SLI config: no Keptn client initialized")
 	}
 
-	customQueries, err := c.client.GetSLIConfiguration(project, stage, service, sliResourceURI)
+	slis, err := c.client.GetSLIConfiguration(project, stage, service, sliResourceURI)
 	if err != nil {
 		return nil, err
 	}
 
-	return &CustomQueries{values: customQueries}, nil
+	return slis, nil
 }
 
 func (c *Client) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {
@@ -119,23 +63,4 @@ func (c *Client) SendCloudEvent(factory adapter.CloudEventFactoryInterface) erro
 	}
 
 	return nil
-}
-
-// based on the requested metric a dynatrace time series with its aggregation type is returned
-func getDefaultQuery(sliName string) (string, error) {
-	// Switched to new metric v2 query language as discussed here: https://github.com/keptn-contrib/dynatrace-sli-service/issues/91
-	switch sliName {
-	case Throughput:
-		return "metricSelector=builtin:service.requestCount.total:merge(\"dt.entity.service\"):sum&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	case errorRate:
-		return "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	case ResponseTimeP50:
-		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	case responseTimeP90:
-		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(90)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	case responseTimeP95:
-		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	default:
-		return "", fmt.Errorf("unsupported SLI %s", sliName)
-	}
 }

--- a/internal/keptn/keptn_client.go
+++ b/internal/keptn/keptn_client.go
@@ -11,20 +11,18 @@ import (
 
 const sliResourceURI = "dynatrace/sli.yaml"
 
+// ClientInterface sends cloud events.
 type ClientInterface interface {
+	// SendCloudEvent sends a cloud event from specified factory or returns an error.
 	SendCloudEvent(factory adapter.CloudEventFactoryInterface) error
 }
 
+// Client is an implementation of ClientInterface.
 type Client struct {
 	client *keptnv2.Keptn
 }
 
-func NewClient(client *keptnv2.Keptn) *Client {
-	return &Client{
-		client: client,
-	}
-}
-
+// NewDefaultClient creates a new Client using the specified event or returns an error.
 func NewDefaultClient(event event.Event) (*Client, error) {
 	keptnOpts := keptnapi.KeptnOpts{
 		ConfigurationServiceURL: getConfigurationServiceURL(),
@@ -34,9 +32,12 @@ func NewDefaultClient(event event.Event) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not create default Keptn client: %v", err)
 	}
-	return NewClient(kClient), nil
+	return &Client{
+		client: kClient,
+	}, nil
 }
 
+// SendCloudEvent sends a cloud event from specified factory or returns an error.
 func (c *Client) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {
 	ev, err := factory.CreateCloudEvent()
 	if err != nil {

--- a/internal/keptn/testdata/config_client/get_slis/sli.invalid_yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli.invalid_yaml
@@ -1,0 +1,3 @@
+spec_version "1.0"
+indicators:
+ response_time metricSelector=builtin:service.response.time:splitBy():percentile(50)

--- a/internal/keptn/testdata/config_client/get_slis/sli_no_indicators.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_no_indicators.yaml
@@ -1,0 +1,1 @@
+spec_version: "1.0"

--- a/internal/keptn/testdata/config_client/get_slis/sli_project.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_project.yaml
@@ -1,0 +1,5 @@
+spec_version: "1.0"
+indicators:
+  sli_c: "metricSelector=builtin:service.response.time:splitBy():percentile(80)&entitySelector=tag(keptn_project:my-project)"
+  sli_d: "metricSelector=builtin:service.response.time:splitBy():percentile(75)&entitySelector=tag(keptn_project:my-project)"
+  sli_f: "metricSelector=builtin:service.response.time:splitBy():percentile(55)&entitySelector=tag(keptn_project:my-project)"

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_50.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_50.yaml
@@ -1,3 +1,0 @@
-spec_version: "1.0"
-indicators:
- response_time: metricSelector=builtin:service.response.time:splitBy():percentile(50)

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_50.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_50.yaml
@@ -1,0 +1,3 @@
+spec_version: "1.0"
+indicators:
+ response_time: metricSelector=builtin:service.response.time:splitBy():percentile(50)

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_90.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_90.yaml
@@ -1,0 +1,3 @@
+spec_version: "1.0"
+indicators:
+ response_time: metricSelector=builtin:service.response.time:splitBy():percentile(90)

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_90.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_90.yaml
@@ -1,3 +1,0 @@
-spec_version: "1.0"
-indicators:
- response_time: metricSelector=builtin:service.response.time:splitBy():percentile(90)

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_95.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_95.yaml
@@ -1,3 +1,0 @@
-spec_version: "1.0"
-indicators:
- response_time: metricSelector=builtin:service.response.time:splitBy():percentile(95)

--- a/internal/keptn/testdata/config_client/get_slis/sli_response_time_95.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_response_time_95.yaml
@@ -1,0 +1,3 @@
+spec_version: "1.0"
+indicators:
+ response_time: metricSelector=builtin:service.response.time:splitBy():percentile(95)

--- a/internal/keptn/testdata/config_client/get_slis/sli_service.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_service.yaml
@@ -1,0 +1,7 @@
+spec_version: "1.0"
+indicators:
+  sli_a: "metricSelector=builtin:service.response.time:splitBy():percentile(95)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage),tag(kept_service:my-service)"
+  sli_b: "metricSelector=builtin:service.response.time:splitBy():percentile(90)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage),tag(kept_service:my-service)"
+  sli_c: "metricSelector=builtin:service.response.time:splitBy():percentile(80)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage),tag(kept_service:my-service)"
+  sli_d: "metricSelector=builtin:service.response.time:splitBy():percentile(75)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage),tag(kept_service:my-service)"
+

--- a/internal/keptn/testdata/config_client/get_slis/sli_stage.yaml
+++ b/internal/keptn/testdata/config_client/get_slis/sli_stage.yaml
@@ -1,0 +1,5 @@
+spec_version: "1.0"
+indicators:
+  sli_b: "metricSelector=builtin:service.response.time:splitBy():percentile(90)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage)"
+  sli_c: "metricSelector=builtin:service.response.time:splitBy():percentile(80)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage)"
+  sli_e: "metricSelector=builtin:service.response.time:splitBy():percentile(70)&entitySelector=tag(keptn_project:my-project),tag(keptn_stage:my-stage)"

--- a/internal/monitoring/auto_tags_creation.go
+++ b/internal/monitoring/auto_tags_creation.go
@@ -8,18 +8,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type AutoTagCreation struct {
+type autoTagCreation struct {
 	client dynatrace.ClientInterface
 }
 
-func NewAutoTagCreation(client dynatrace.ClientInterface) *AutoTagCreation {
-	return &AutoTagCreation{
+func newAutoTagCreation(client dynatrace.ClientInterface) *autoTagCreation {
+	return &autoTagCreation{
 		client: client,
 	}
 }
 
-// Create creates auto-tags in Dynatrace and returns the tagging rules.
-func (at *AutoTagCreation) Create(ctx context.Context) []ConfigResult {
+// create creates auto-tags in Dynatrace and returns the tagging rules.
+func (at *autoTagCreation) create(ctx context.Context) []configResult {
 	log.Info("Setting up auto-tagging rules in Dynatrace Tenant")
 
 	autoTagsClient := dynatrace.NewAutoTagClient(at.client)
@@ -30,7 +30,7 @@ func (at *AutoTagCreation) Create(ctx context.Context) []ConfigResult {
 		log.WithError(err).Error("Failed retrieving Dynatrace tagging rules")
 	}
 
-	var taggingRulesResults []ConfigResult
+	var taggingRulesResults []configResult
 	for _, ruleName := range []string{"keptn_service", "keptn_stage", "keptn_project", "keptn_deployment"} {
 		taggingRulesResults = append(
 			taggingRulesResults,
@@ -39,7 +39,7 @@ func (at *AutoTagCreation) Create(ctx context.Context) []ConfigResult {
 	return taggingRulesResults
 }
 
-func createAutoTaggingRuleForRuleName(ctx context.Context, client *dynatrace.AutoTagsClient, existingTagNames *dynatrace.TagNames, ruleName string) ConfigResult {
+func createAutoTaggingRuleForRuleName(ctx context.Context, client *dynatrace.AutoTagsClient, existingTagNames *dynatrace.TagNames, ruleName string) configResult {
 	if !existingTagNames.Contains(ruleName) {
 		rule := createAutoTaggingRuleDTO(ruleName)
 
@@ -47,21 +47,21 @@ func createAutoTaggingRuleForRuleName(ctx context.Context, client *dynatrace.Aut
 		if err != nil {
 			// Error occurred but continue
 			log.WithError(err).Error("Could not create auto tagging rule")
-			return ConfigResult{
+			return configResult{
 				Name:    ruleName,
 				Success: false,
 				Message: "Could not create auto tagging rule: " + err.Error(),
 			}
 		}
 
-		return ConfigResult{
+		return configResult{
 			Name:    ruleName,
 			Success: true,
 		}
 	}
 
 	log.WithField("ruleName", ruleName).Info("Tagging rule already exists")
-	return ConfigResult{
+	return configResult{
 		Name:    ruleName,
 		Message: "Tagging rule " + ruleName + " already exists",
 		Success: true,

--- a/internal/monitoring/configuration.go
+++ b/internal/monitoring/configuration.go
@@ -26,18 +26,18 @@ type ConfigResult struct {
 }
 
 type Configuration struct {
-	dtClient      dynatrace.ClientInterface
-	kClient       keptn.ClientInterface
-	sloReader     keptn.SLOReaderInterface
-	serviceClient keptn.ServiceClientInterface
+	dtClient        dynatrace.ClientInterface
+	kClient         keptn.ClientInterface
+	sliAndSLOReader keptn.SLIAndSLOReaderInterface
+	serviceClient   keptn.ServiceClientInterface
 }
 
-func NewConfiguration(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sloReader keptn.SLOReaderInterface, serviceClient keptn.ServiceClientInterface) *Configuration {
+func NewConfiguration(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sliAndSLOReader keptn.SLIAndSLOReaderInterface, serviceClient keptn.ServiceClientInterface) *Configuration {
 	return &Configuration{
-		dtClient:      dynatraceClient,
-		kClient:       keptnClient,
-		sloReader:     sloReader,
-		serviceClient: serviceClient,
+		dtClient:        dynatraceClient,
+		kClient:         keptnClient,
+		sliAndSLOReader: sliAndSLOReader,
+		serviceClient:   serviceClient,
 	}
 }
 
@@ -90,7 +90,7 @@ func (mc *Configuration) createMetricEventsForStage(ctx context.Context, project
 	for _, serviceName := range serviceNames {
 		metricEvents = append(
 			metricEvents,
-			NewMetricEventCreation(mc.dtClient, mc.kClient, mc.sloReader).Create(ctx, project, stage.Name, serviceName)...)
+			NewMetricEventCreation(mc.dtClient, mc.kClient, mc.sliAndSLOReader).Create(ctx, project, stage.Name, serviceName)...)
 	}
 	return metricEvents
 }

--- a/internal/monitoring/configure_monitoring_event_handler.go
+++ b/internal/monitoring/configure_monitoring_event_handler.go
@@ -23,19 +23,19 @@ type ConfigureMonitoringEventHandler struct {
 	dtClient           dynatrace.ClientInterface
 	kClient            keptn.ClientInterface
 	shipyardReader     keptn.ShipyardReaderInterface
-	sloReader          keptn.SLOReaderInterface
+	sliAndSLOReader    keptn.SLIAndSLOReaderInterface
 	serviceClient      keptn.ServiceClientInterface
 	credentialsChecker keptn.CredentialsCheckerInterface
 }
 
 // NewConfigureMonitoringEventHandler returns a new ConfigureMonitoringEventHandler
-func NewConfigureMonitoringEventHandler(event ConfigureMonitoringAdapterInterface, dtClient dynatrace.ClientInterface, kClient keptn.ClientInterface, shipyardReader keptn.ShipyardReaderInterface, sloReader keptn.SLOReaderInterface, serviceClient keptn.ServiceClientInterface, credentialsChecker keptn.CredentialsCheckerInterface) ConfigureMonitoringEventHandler {
+func NewConfigureMonitoringEventHandler(event ConfigureMonitoringAdapterInterface, dtClient dynatrace.ClientInterface, kClient keptn.ClientInterface, shipyardReader keptn.ShipyardReaderInterface, sliAndSLOReader keptn.SLIAndSLOReaderInterface, serviceClient keptn.ServiceClientInterface, credentialsChecker keptn.CredentialsCheckerInterface) ConfigureMonitoringEventHandler {
 	return ConfigureMonitoringEventHandler{
 		event:              event,
 		dtClient:           dtClient,
 		kClient:            kClient,
 		shipyardReader:     shipyardReader,
-		sloReader:          sloReader,
+		sliAndSLOReader:    sliAndSLOReader,
 		serviceClient:      serviceClient,
 		credentialsChecker: credentialsChecker,
 	}
@@ -64,7 +64,7 @@ func (eh *ConfigureMonitoringEventHandler) configureMonitoring(ctx context.Conte
 		return eh.handleError(err)
 	}
 
-	cfg := NewConfiguration(eh.dtClient, eh.kClient, eh.sloReader, eh.serviceClient)
+	cfg := NewConfiguration(eh.dtClient, eh.kClient, eh.sliAndSLOReader, eh.serviceClient)
 
 	configuredEntities, err := cfg.ConfigureMonitoring(ctx, eh.event.GetProject(), *shipyard)
 	if err != nil {

--- a/internal/monitoring/configure_monitoring_event_handler.go
+++ b/internal/monitoring/configure_monitoring_event_handler.go
@@ -64,9 +64,9 @@ func (eh *ConfigureMonitoringEventHandler) configureMonitoring(ctx context.Conte
 		return eh.handleError(err)
 	}
 
-	cfg := NewConfiguration(eh.dtClient, eh.kClient, eh.sliAndSLOReader, eh.serviceClient)
+	cfg := newConfiguration(eh.dtClient, eh.kClient, eh.sliAndSLOReader, eh.serviceClient)
 
-	configuredEntities, err := cfg.ConfigureMonitoring(ctx, eh.event.GetProject(), *shipyard)
+	configuredEntities, err := cfg.configureMonitoring(ctx, eh.event.GetProject(), *shipyard)
 	if err != nil {
 		return eh.handleError(err)
 	}
@@ -101,7 +101,7 @@ func (eh *ConfigureMonitoringEventHandler) checkKeptnCredentials(ctx context.Con
 
 }
 
-func getConfigureMonitoringResultMessage(keptnCredentialsCheckResult keptnCredentialsCheckResult, entities *ConfiguredEntities) string {
+func getConfigureMonitoringResultMessage(keptnCredentialsCheckResult keptnCredentialsCheckResult, entities *configuredEntities) string {
 	if entities == nil {
 		return ""
 	}

--- a/internal/monitoring/configure_monitoring_event_handler.go
+++ b/internal/monitoring/configure_monitoring_event_handler.go
@@ -22,17 +22,19 @@ type ConfigureMonitoringEventHandler struct {
 	event              ConfigureMonitoringAdapterInterface
 	dtClient           dynatrace.ClientInterface
 	kClient            keptn.ClientInterface
+	shipyardReader     keptn.ShipyardReaderInterface
 	sloReader          keptn.SLOReaderInterface
 	serviceClient      keptn.ServiceClientInterface
 	credentialsChecker keptn.CredentialsCheckerInterface
 }
 
 // NewConfigureMonitoringEventHandler returns a new ConfigureMonitoringEventHandler
-func NewConfigureMonitoringEventHandler(event ConfigureMonitoringAdapterInterface, dtClient dynatrace.ClientInterface, kClient keptn.ClientInterface, sloReader keptn.SLOReaderInterface, serviceClient keptn.ServiceClientInterface, credentialsChecker keptn.CredentialsCheckerInterface) ConfigureMonitoringEventHandler {
+func NewConfigureMonitoringEventHandler(event ConfigureMonitoringAdapterInterface, dtClient dynatrace.ClientInterface, kClient keptn.ClientInterface, shipyardReader keptn.ShipyardReaderInterface, sloReader keptn.SLOReaderInterface, serviceClient keptn.ServiceClientInterface, credentialsChecker keptn.CredentialsCheckerInterface) ConfigureMonitoringEventHandler {
 	return ConfigureMonitoringEventHandler{
 		event:              event,
 		dtClient:           dtClient,
 		kClient:            kClient,
+		shipyardReader:     shipyardReader,
 		sloReader:          sloReader,
 		serviceClient:      serviceClient,
 		credentialsChecker: credentialsChecker,
@@ -57,7 +59,7 @@ func (eh *ConfigureMonitoringEventHandler) configureMonitoring(ctx context.Conte
 	keptnCredentialsCheckResult := eh.checkKeptnCredentials(ctx)
 	log.WithField("result", keptnCredentialsCheckResult).Info("Checked Keptn credentials")
 
-	shipyard, err := eh.kClient.GetShipyard()
+	shipyard, err := eh.shipyardReader.GetShipyard(eh.event.GetProject())
 	if err != nil {
 		return eh.handleError(err)
 	}

--- a/internal/monitoring/dashboard_creation.go
+++ b/internal/monitoring/dashboard_creation.go
@@ -16,24 +16,24 @@ const customChartName = "Custom Chart"
 const timeSeriesChartType = "TIMESERIES"
 const dashboardStageWidth int = 456
 
-type DashboardCreation struct {
+type dashboardCreation struct {
 	client dynatrace.ClientInterface
 }
 
-func NewDashboardCreation(client dynatrace.ClientInterface) *DashboardCreation {
-	return &DashboardCreation{
+func newDashboardCreation(client dynatrace.ClientInterface) *dashboardCreation {
+	return &dashboardCreation{
 		client: client,
 	}
 }
 
-// Create creates a new dashboard for the provided project.
-func (dc *DashboardCreation) Create(ctx context.Context, project string, shipyard keptnv2.Shipyard) *ConfigResult {
+// create creates a new dashboard for the provided project.
+func (dc *dashboardCreation) create(ctx context.Context, project string, shipyard keptnv2.Shipyard) *configResult {
 	// first, check if dashboard for this project already exists and delete that
 	dashboardClient := dynatrace.NewDashboardsClient(dc.client)
 	err := deleteExistingDashboard(ctx, project, dashboardClient)
 	if err != nil {
 		log.WithError(err).Error("Could not delete existing dashboard")
-		return &ConfigResult{
+		return &configResult{
 			Success: false,
 			Message: "Could not delete existing dashboard: " + err.Error(),
 		}
@@ -44,13 +44,13 @@ func (dc *DashboardCreation) Create(ctx context.Context, project string, shipyar
 	err = dashboardClient.Create(ctx, dashboard)
 	if err != nil {
 		log.WithError(err).Error("Failed to create Dynatrace dashboards")
-		return &ConfigResult{
+		return &configResult{
 			Success: false,
 			Message: err.Error(),
 		}
 	}
 	log.WithField("dashboardUrl", dc.client.Credentials().GetTenant()+"/#dashboards").Info("Dynatrace dashboard created successfully")
-	return &ConfigResult{
+	return &configResult{
 		Success: true, // I guess this should be true not false?
 		Message: "Dynatrace dashboard created successfully. You can view it here: " + dc.client.Credentials().GetTenant() + "/#dashboards",
 	}

--- a/internal/monitoring/management_zones_creation.go
+++ b/internal/monitoring/management_zones_creation.go
@@ -9,18 +9,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type ManagementZoneCreation struct {
+type managementZoneCreation struct {
 	client dynatrace.ClientInterface
 }
 
-func NewManagementZoneCreation(client dynatrace.ClientInterface) *ManagementZoneCreation {
-	return &ManagementZoneCreation{
+func newManagementZoneCreation(client dynatrace.ClientInterface) *managementZoneCreation {
+	return &managementZoneCreation{
 		client: client,
 	}
 }
 
-// Create creates a new management zone for the project.
-func (mzc *ManagementZoneCreation) Create(ctx context.Context, project string, shipyard keptnv2.Shipyard) []ConfigResult {
+// create creates a new management zone for the project.
+func (mzc *managementZoneCreation) create(ctx context.Context, project string, shipyard keptnv2.Shipyard) []configResult {
 	// get existing management zones
 	managementZoneClient := dynatrace.NewManagementZonesClient(mzc.client)
 	managementZoneNames, err := managementZoneClient.GetAll(ctx)
@@ -29,7 +29,7 @@ func (mzc *ManagementZoneCreation) Create(ctx context.Context, project string, s
 		log.WithError(err).Error("Could not retrieve management zones")
 	}
 
-	var managementZonesResults []ConfigResult
+	var managementZonesResults []configResult
 	managementZoneResult := getOrCreateManagementZone(
 		ctx,
 		managementZoneClient,
@@ -60,9 +60,9 @@ func getOrCreateManagementZone(
 	managementZoneClient *dynatrace.ManagementZonesClient,
 	managementZoneName string,
 	managementZoneFunc func() *dynatrace.ManagementZone,
-	managementZoneNames *dynatrace.ManagementZones) ConfigResult {
+	managementZoneNames *dynatrace.ManagementZones) configResult {
 	if managementZoneNames != nil && managementZoneNames.Contains(managementZoneName) {
-		return ConfigResult{
+		return configResult{
 			Name:    managementZoneName,
 			Success: true,
 			Message: "Management Zone '" + managementZoneName + "' was already available in your Tenant",
@@ -72,14 +72,14 @@ func getOrCreateManagementZone(
 	err := managementZoneClient.Create(ctx, managementZoneFunc())
 	if err != nil {
 		log.WithError(err).Error("Failed to create management zone")
-		return ConfigResult{
+		return configResult{
 			Name:    managementZoneName,
 			Success: false,
 			Message: "failed to create management zone: " + err.Error(),
 		}
 	}
 
-	return ConfigResult{
+	return configResult{
 		Name:    managementZoneName,
 		Success: true,
 	}

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -19,7 +19,7 @@ import (
 const keptnService = "keptn_service"
 const keptnDeployment = "keptn_deployment"
 
-type CriteriaObject struct {
+type criteriaObject struct {
 	Operator        string
 	Value           float64
 	CheckPercentage bool
@@ -27,22 +27,22 @@ type CriteriaObject struct {
 	CheckIncrease   bool
 }
 
-type MetricEventCreation struct {
+type metricEventCreation struct {
 	dtClient        dynatrace.ClientInterface
 	kClient         keptn.ClientInterface
 	sliAndSLOReader keptn.SLIAndSLOReaderInterface
 }
 
-func NewMetricEventCreation(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sliAndSLOReader keptn.SLIAndSLOReaderInterface) MetricEventCreation {
-	return MetricEventCreation{
+func newMetricEventCreation(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sliAndSLOReader keptn.SLIAndSLOReaderInterface) metricEventCreation {
+	return metricEventCreation{
 		dtClient:        dynatraceClient,
 		kClient:         keptnClient,
 		sliAndSLOReader: sliAndSLOReader,
 	}
 }
 
-// Create creates new metric events if SLOs are specified.
-func (mec MetricEventCreation) Create(ctx context.Context, project string, stage string, service string) []ConfigResult {
+// create creates new metric events if SLOs are specified.
+func (mec metricEventCreation) create(ctx context.Context, project string, stage string, service string) []configResult {
 	log.Info("Creating custom metric events for project SLIs")
 	slos, err := mec.sliAndSLOReader.GetSLOs(project, stage, service)
 	if err != nil {
@@ -80,7 +80,7 @@ func (mec MetricEventCreation) Create(ctx context.Context, project string, stage
 	}
 
 	metricEventsClient := dynatrace.NewMetricEventsClient(mec.dtClient)
-	var metricsEventResults []ConfigResult
+	var metricsEventResults []configResult
 	// try to create metric events using best effort.
 	for _, objective := range slos.Objectives {
 		query, err := projectCustomQueries.GetQueryByNameOrDefault(objective.SLI)
@@ -109,8 +109,8 @@ func (mec MetricEventCreation) Create(ctx context.Context, project string, stage
 	return metricsEventResults
 }
 
-func setupAllMetricEvents(ctx context.Context, client *dynatrace.MetricEventsClient, project string, stage string, service string, slo *keptnlib.SLO, query string, managementZoneID int64) []ConfigResult {
-	var metricEventsResults []ConfigResult
+func setupAllMetricEvents(ctx context.Context, client *dynatrace.MetricEventsClient, project string, stage string, service string, slo *keptnlib.SLO, query string, managementZoneID int64) []configResult {
+	var metricEventsResults []configResult
 	for _, criteria := range slo.Pass {
 		for _, crit := range criteria.Criteria {
 
@@ -126,7 +126,7 @@ func setupAllMetricEvents(ctx context.Context, client *dynatrace.MetricEventsCli
 	return metricEventsResults
 }
 
-func setupSingleMetricEvent(ctx context.Context, client *dynatrace.MetricEventsClient, project string, stage string, service string, metric string, query string, crit string, managementZoneID int64) (*ConfigResult, error) {
+func setupSingleMetricEvent(ctx context.Context, client *dynatrace.MetricEventsClient, project string, stage string, service string, metric string, query string, crit string, managementZoneID int64) (*configResult, error) {
 	// criteria.Criteria
 	criteriaObject, err := parseCriteriaString(crit)
 	if err != nil {
@@ -158,7 +158,7 @@ func setupSingleMetricEvent(ctx context.Context, client *dynatrace.MetricEventsC
 	}
 
 	log.WithFields(log.Fields{"name": newMetricEvent.Name, "criteria": crit}).Info("Created metric event")
-	return &ConfigResult{
+	return &configResult{
 		Name:    newMetricEvent.Name,
 		Success: true,
 	}, nil
@@ -191,7 +191,7 @@ func createOrUpdateMetricEvent(ctx context.Context, client *dynatrace.MetricEven
 	return nil
 }
 
-func parseCriteriaString(criteria string) (*CriteriaObject, error) {
+func parseCriteriaString(criteria string) (*criteriaObject, error) {
 	// example values: <+15%, <500, >-8%, =0
 	// possible operators: <, <=, =, >, >=
 	// regex: ^([<|<=|=|>|>=]{1,2})([+|-]{0,1}\\d*\.?\d*)([%]{0,1})
@@ -206,7 +206,7 @@ func parseCriteriaString(criteria string) (*CriteriaObject, error) {
 		return nil, errors.New("invalid criteria string")
 	}
 
-	c := &CriteriaObject{}
+	c := &criteriaObject{}
 
 	if strings.HasSuffix(criteria, "%") {
 		c.CheckPercentage = true

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -28,23 +28,23 @@ type CriteriaObject struct {
 }
 
 type MetricEventCreation struct {
-	dtClient  dynatrace.ClientInterface
-	kClient   keptn.ClientInterface
-	sloReader keptn.SLOReaderInterface
+	dtClient        dynatrace.ClientInterface
+	kClient         keptn.ClientInterface
+	sliAndSLOReader keptn.SLIAndSLOReaderInterface
 }
 
-func NewMetricEventCreation(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sloReader keptn.SLOReaderInterface) MetricEventCreation {
+func NewMetricEventCreation(dynatraceClient dynatrace.ClientInterface, keptnClient keptn.ClientInterface, sliAndSLOReader keptn.SLIAndSLOReaderInterface) MetricEventCreation {
 	return MetricEventCreation{
-		dtClient:  dynatraceClient,
-		kClient:   keptnClient,
-		sloReader: sloReader,
+		dtClient:        dynatraceClient,
+		kClient:         keptnClient,
+		sliAndSLOReader: sliAndSLOReader,
 	}
 }
 
 // Create creates new metric events if SLOs are specified.
 func (mec MetricEventCreation) Create(ctx context.Context, project string, stage string, service string) []ConfigResult {
 	log.Info("Creating custom metric events for project SLIs")
-	slos, err := mec.sloReader.GetSLOs(project, stage, service)
+	slos, err := mec.sliAndSLOReader.GetSLOs(project, stage, service)
 	if err != nil {
 		log.WithError(err).WithFields(
 			log.Fields{
@@ -54,7 +54,7 @@ func (mec MetricEventCreation) Create(ctx context.Context, project string, stage
 	}
 
 	// get custom metrics for project
-	slis, err := mec.kClient.GetSLIs(project, stage, service)
+	slis, err := mec.sliAndSLOReader.GetSLIs(project, stage, service)
 	if err != nil {
 		log.WithError(err).WithField("project", project).Error("Failed to get SLIs for project")
 		return nil

--- a/internal/monitoring/metric_events_creation.go
+++ b/internal/monitoring/metric_events_creation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
+	"github.com/keptn-contrib/dynatrace-service/internal/sli/query"
 	keptnlib "github.com/keptn/go-utils/pkg/lib"
 
 	log "github.com/sirupsen/logrus"
@@ -51,13 +52,14 @@ func (mec MetricEventCreation) Create(ctx context.Context, project string, stage
 				"stage":   stage}).Info("No SLOs defined for service. Skipping creation of custom metric events.")
 		return nil
 	}
-	// get custom metrics for project
 
-	projectCustomQueries, err := mec.kClient.GetCustomQueries(project, stage, service)
+	// get custom metrics for project
+	slis, err := mec.kClient.GetSLIs(project, stage, service)
 	if err != nil {
-		log.WithError(err).WithField("project", project).Error("Failed to get custom queries for project")
+		log.WithError(err).WithField("project", project).Error("Failed to get SLIs for project")
 		return nil
 	}
+	projectCustomQueries := query.NewCustomQueries(slis)
 
 	managementZones, err := dynatrace.NewManagementZonesClient(mec.dtClient).GetAll(ctx)
 	var mzId int64 = -1

--- a/internal/monitoring/problem_notification_creation.go
+++ b/internal/monitoring/problem_notification_creation.go
@@ -10,24 +10,24 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type ProblemNotificationCreation struct {
+type problemNotificationCreation struct {
 	client dynatrace.ClientInterface
 }
 
-func NewProblemNotificationCreation(client dynatrace.ClientInterface) *ProblemNotificationCreation {
-	return &ProblemNotificationCreation{
+func newProblemNotificationCreation(client dynatrace.ClientInterface) *problemNotificationCreation {
+	return &problemNotificationCreation{
 		client: client,
 	}
 }
 
-// Create sets up/updates the DT problem notification and returns it.
-func (pn *ProblemNotificationCreation) Create(ctx context.Context, project string) *ConfigResult {
+// create sets up/updates the DT problem notification and returns it.
+func (pn *problemNotificationCreation) create(ctx context.Context, project string) *configResult {
 	log.Info("Setting up problem notifications in Dynatrace Tenant")
 
 	alertingProfileID, err := getOrCreateKeptnAlertingProfile(ctx, dynatrace.NewAlertingProfilesClient(pn.client))
 	if err != nil {
 		log.WithError(err).Error("Failed to set up problem notification")
-		return &ConfigResult{
+		return &configResult{
 			Success: false,
 			Message: "failed to set up problem notification: " + err.Error(),
 		}
@@ -42,7 +42,7 @@ func (pn *ProblemNotificationCreation) Create(ctx context.Context, project strin
 	keptnCredentials, err := credentials.GetKeptnCredentials(ctx)
 	if err != nil {
 		log.WithError(err).Error("Failed to retrieve Keptn API credentials")
-		return &ConfigResult{
+		return &configResult{
 			Success: false,
 			Message: "failed to retrieve Keptn API credentials: " + err.Error(),
 		}
@@ -51,13 +51,13 @@ func (pn *ProblemNotificationCreation) Create(ctx context.Context, project strin
 	err = notificationsClient.Create(ctx, keptnCredentials, alertingProfileID, project)
 	if err != nil {
 		log.WithError(err).Error("Failed to create problem notification")
-		return &ConfigResult{
+		return &configResult{
 			Success: false,
 			Message: "failed to set up problem notification: " + err.Error(),
 		}
 	}
 
-	return &ConfigResult{
+	return &configResult{
 		Success: true,
 		Message: "Successfully set up Keptn Alerting Profile and Problem Notifications",
 	}

--- a/internal/problem/problem_event_handler_test.go
+++ b/internal/problem/problem_event_handler_test.go
@@ -10,7 +10,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
-	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,10 +81,6 @@ type keptnClientMock struct {
 
 func (m *keptnClientMock) GetCustomQueries(project string, stage string, service string) (*keptn.CustomQueries, error) {
 	panic("GetCustomQueries() should not be needed in this mock!")
-}
-
-func (m *keptnClientMock) GetShipyard() (*keptnv2.Shipyard, error) {
-	panic("GetShipyard() should not be needed in this mock!")
 }
 
 func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/problem/problem_event_handler_test.go
+++ b/internal/problem/problem_event_handler_test.go
@@ -9,7 +9,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
-	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,8 +78,8 @@ type keptnClientMock struct {
 	eventSink []*cloudevents.Event
 }
 
-func (m *keptnClientMock) GetCustomQueries(project string, stage string, service string) (*keptn.CustomQueries, error) {
-	panic("GetCustomQueries() should not be needed in this mock!")
+func (m *keptnClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
+	panic("GetSLIs() should not be needed in this mock!")
 }
 
 func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -150,14 +150,13 @@ func (eh *GetSLIEventHandler) getSLIResultsFromDynatraceDashboard(ctx context.Co
 }
 
 func (eh *GetSLIEventHandler) getSLIResultsFromCustomQueries(ctx context.Context, timeframe common.Timeframe) ([]result.SLIResult, error) {
-	// get custom metrics for project if they exist
-	projectCustomQueries, err := eh.kClient.GetCustomQueries(eh.event.GetProject(), eh.event.GetStage(), eh.event.GetService())
+	slis, err := eh.kClient.GetSLIs(eh.event.GetProject(), eh.event.GetStage(), eh.event.GetService())
 	if err != nil {
-		log.WithError(err).Errorf("could not retrieve custom queries: %v", err)
+		log.WithError(err).Error("could not retrieve custom SLI definitions")
 		return nil, fmt.Errorf("could not retrieve custom SLI definitions: %w", err)
 	}
 
-	queryProcessing := query.NewProcessing(eh.dtClient, eh.event, eh.event.GetCustomSLIFilters(), projectCustomQueries, timeframe)
+	queryProcessing := query.NewProcessing(eh.dtClient, eh.event, eh.event.GetCustomSLIFilters(), query.NewCustomQueries(slis), timeframe)
 
 	var sliResults []result.SLIResult
 

--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -150,7 +150,7 @@ func (eh *GetSLIEventHandler) getSLIResultsFromDynatraceDashboard(ctx context.Co
 }
 
 func (eh *GetSLIEventHandler) getSLIResultsFromCustomQueries(ctx context.Context, timeframe common.Timeframe) ([]result.SLIResult, error) {
-	slis, err := eh.kClient.GetSLIs(eh.event.GetProject(), eh.event.GetStage(), eh.event.GetService())
+	slis, err := eh.resourceClient.GetSLIs(eh.event.GetProject(), eh.event.GetStage(), eh.event.GetService())
 	if err != nil {
 		log.WithError(err).Error("could not retrieve custom SLI definitions")
 		return nil, fmt.Errorf("could not retrieve custom SLI definitions: %w", err)

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
@@ -24,9 +24,13 @@ type uploadErrorResourceClientMock struct {
 	uploadedSLOs   *keptnapi.ServiceLevelObjectives
 }
 
+func (m *uploadErrorResourceClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
+	m.t.Fatalf("GetSLIs() should not be needed in this mock!")
+	return nil, nil
+}
+
 func (m *uploadErrorResourceClientMock) GetSLOs(project string, stage string, service string) (*keptnapi.ServiceLevelObjectives, error) {
 	m.t.Fatalf("GetSLOs() should not be needed in this mock!")
-
 	return nil, nil
 }
 
@@ -150,21 +154,23 @@ type uploadWillFailResourceClientMock struct {
 	t *testing.T
 }
 
+func (m *uploadWillFailResourceClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
+	m.t.Fatalf("GetSLIs() should not be needed in this mock!")
+	return nil, nil
+}
+
 func (m *uploadWillFailResourceClientMock) GetSLOs(project string, stage string, service string) (*keptnapi.ServiceLevelObjectives, error) {
 	m.t.Fatalf("GetSLOs() should not be needed in this mock!")
-
 	return nil, nil
 }
 
 func (m *uploadWillFailResourceClientMock) UploadSLIs(project string, stage string, service string, slis *dynatrace.SLI) error {
 	m.t.Fatalf("UploadSLIs() should not be needed in this mock!")
-
 	return nil
 }
 
 func (m *uploadWillFailResourceClientMock) UploadSLOs(project string, stage string, service string, slos *keptnapi.ServiceLevelObjectives) error {
 	m.t.Fatalf("UploadSLOs() should not be needed in this mock!")
-
 	return nil
 }
 
@@ -214,8 +220,6 @@ func TestThatFallbackToSLIsFromDashboardIfDashboardDidNotChangeWorks(t *testing.
 }
 
 func runAndAssertThatDashboardTestIsCorrect(t *testing.T, getSLIEventData *getSLIEventData, handler http.Handler, rClient keptn.SLOAndSLIClientInterface, getSLIFinishedEventAssertionsFunc func(t *testing.T, actual *keptnv2.GetSLIFinishedEventData), sliResultAssertionsFuncs ...func(t *testing.T, actual *keptnv2.SLIResult)) {
-
-	// we do not need custom queries, as we are using the dashboard
 	kClient := &keptnClientMock{}
 
 	runTestAndAssertNoError(t, getSLIEventData, handler, kClient, rClient, testDashboardID)

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
@@ -25,7 +25,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsA
 
 	// error here as well: merge("dt.entity.services")
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.services\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}
@@ -56,7 +56,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(
 
 	// error here as well: tag(keptn_project:stagin)
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:stagin)",
 		},
 	}
@@ -87,7 +87,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsMultipleRe
 
 	// error here as well: missing merge("dt.entity.service) transformation
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}
@@ -145,7 +145,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsUsingWrongMetri
 
 			// error here: in value of tc.mv2Prefix
 			kClient := &keptnClientMock{
-				customQueries: map[string]string{
+				slis: map[string]string{
 					indicator: tc.mv2Prefix + "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 				},
 			}
@@ -194,7 +194,7 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 		"./testdata/response_time_p95_200_1_result.json")
 
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
@@ -23,12 +23,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsA
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.services%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
 		"./testdata/response_time_p95_200_0_result_warning_entity-selector.json")
 
+	kClient := &keptnClientMock{}
+
 	// error here as well: merge("dt.entity.services")
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.services\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-		},
-	}
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.services\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+	})
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -38,7 +38,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResultsA
 		assert.Contains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -54,12 +54,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astagin%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
 		"./testdata/response_time_p95_200_0_result_wrong-tag.json")
 
+	kClient := &keptnClientMock{}
+
 	// error here as well: tag(keptn_project:stagin)
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:stagin)",
-		},
-	}
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:stagin)",
+	})
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -69,7 +69,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsNoResults(
 		assert.NotContains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -85,12 +85,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsMultipleRe
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
 		"./testdata/response_time_p95_200_3_results.json")
 
+	kClient := &keptnClientMock{}
+
 	// error here as well: missing merge("dt.entity.service) transformation
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			indicator: "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-		},
-	}
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		indicator: "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+	})
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -100,7 +100,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryReturnsMultipleRe
 		assert.NotContains(t, actual.Message, "Warning")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventWarningAssertionsFunc, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -143,12 +143,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsUsingWrongMetri
 			// no handler needed
 			handler := test.NewFileBasedURLHandler(t)
 
+			kClient := &keptnClientMock{}
+
 			// error here: in value of tc.mv2Prefix
-			kClient := &keptnClientMock{
-				slis: map[string]string{
-					indicator: tc.mv2Prefix + "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-				},
-			}
+			rClient := newResourceClientMockWithSLIs(t, map[string]string{
+				indicator: tc.mv2Prefix + "metricSelector=builtin:service.response.time:percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+			})
 
 			sliResultAssertionsFunc := func(t *testing.T, sliResult *keptnv2.SLIResult) {
 				assert.EqualValues(t, indicator, sliResult.Metric)
@@ -157,7 +157,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsUsingWrongMetri
 				assert.Contains(t, sliResult.Message, "error parsing MV2 query")
 			}
 
-			assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
+			assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
 		})
 	}
 }
@@ -175,12 +175,14 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreDefinedButEmpty(t *testing.T) {
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29%2Ctag%28keptn_service%3Acarts%29%2Ctag%28keptn_deployment%3A%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
 		"./testdata/response_time_p95_200_1_result_defaults.json")
 
+	kClient := &keptnClientMock{}
+
 	// no custom queries defined here
 	// currently this could have 2 reasons: EITHER no sli.yaml file available OR no indicators defined in such a file)
 	// TODO 2021-09-29: we should be able to differentiate between 'not there' and 'no SLIs defined' - the latter could be intentional
-	kClient := &keptnClientMock{}
+	rClient := newResourceClientMock(t)
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(indicator, 12.439619479902443))
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(indicator, 12.439619479902443))
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -193,11 +195,11 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 		dynatrace.MetricsQueryPath+"?entitySelector=type%28SERVICE%29%2Ctag%28keptn_project%3Asockshop%29%2Ctag%28keptn_stage%3Astaging%29&from=1632834999000&metricSelector=builtin%3Aservice.response.time%3Amerge%28%22dt.entity.service%22%29%3Apercentile%2895%29&resolution=Inf&to=1632835299000",
 		"./testdata/response_time_p95_200_1_result.json")
 
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-		},
-	}
+	kClient := &keptnClientMock{}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(indicator, 12.439619479902443))
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		indicator: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+	})
+
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(indicator, 12.439619479902443))
 }

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
@@ -23,7 +23,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 
 	// error here in the misspelled indicator:
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			"response_time_p59": "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}
@@ -49,7 +49,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 
 	// error here as well: metric(s)Selector=
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 		},
 	}
@@ -75,7 +75,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreInvalidYAML(t *testing.T) {
 
 	const errorMessage = "invalid YAML file - some parsing issue"
 	kClient := &keptnClientMock{
-		customQueriesError: fmt.Errorf(errorMessage),
+		getSLIsError: fmt.Errorf(errorMessage),
 	}
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_test.go
@@ -21,12 +21,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 	// no need to have something here, because we should not send an API request
 	handler := test.NewFileBasedURLHandler(t)
 
+	kClient := &keptnClientMock{}
+
 	// error here in the misspelled indicator:
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			"response_time_p59": "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-		},
-	}
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		"response_time_p59": "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+	})
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -35,7 +35,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButIndicatorCannotBeMatch
 		assert.Contains(t, actual.Message, "response_time_p95")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -47,12 +47,12 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 	// error here: metric(s)Selector=
 	handler := test.NewFileBasedURLHandler(t)
 
+	kClient := &keptnClientMock{}
+
 	// error here as well: metric(s)Selector=
-	kClient := &keptnClientMock{
-		slis: map[string]string{
-			indicator: "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
-		},
-	}
+	rClient := newResourceClientMockWithSLIs(t, map[string]string{
+		indicator: "metricsSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
+	})
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -61,7 +61,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreValidYAMLButQueryIsNotValid(t *tes
 		assert.Contains(t, actual.Message, "error parsing Metrics v2 query")
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -73,10 +73,10 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreInvalidYAML(t *testing.T) {
 	// make sure we would not be able to query any metric due to a parsing error
 	handler := test.NewFileBasedURLHandler(t)
 
+	kClient := &keptnClientMock{}
+
 	const errorMessage = "invalid YAML file - some parsing issue"
-	kClient := &keptnClientMock{
-		getSLIsError: fmt.Errorf(errorMessage),
-	}
+	rClient := newResourceClientMockWithGetSLIsError(t, fmt.Errorf(errorMessage))
 
 	sliResultAssertionsFunc := func(t *testing.T, actual *keptnv2.SLIResult) {
 		assert.EqualValues(t, indicator, actual.Metric)
@@ -85,13 +85,13 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreInvalidYAML(t *testing.T) {
 		assert.Contains(t, actual.Message, errorMessage)
 	}
 
-	assertThatCustomSLITestIsCorrect(t, handler, kClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
+	assertThatCustomSLITestIsCorrect(t, handler, kClient, rClient, getSLIFinishedEventFailureAssertionsFunc, sliResultAssertionsFunc)
 }
 
-func assertThatCustomSLITestIsCorrect(t *testing.T, handler http.Handler, kClient *keptnClientMock, getSLIFinishedEventAssertionsFunc func(t *testing.T, data *keptnv2.GetSLIFinishedEventData), sliResultAssertionsFunc func(t *testing.T, actual *keptnv2.SLIResult)) {
+func assertThatCustomSLITestIsCorrect(t *testing.T, handler http.Handler, kClient *keptnClientMock, rClient *resourceClientMock, getSLIFinishedEventAssertionsFunc func(t *testing.T, data *keptnv2.GetSLIFinishedEventData), sliResultAssertionsFunc func(t *testing.T, actual *keptnv2.SLIResult)) {
 	// we use the special mock for the resource client
 	// we do not want to query a dashboard, so we leave it empty
-	runTestAndAssertNoError(t, testGetSLIEventDataWithDefaultStartAndEnd, handler, kClient, &resourceClientMock{t: t}, "")
+	runTestAndAssertNoError(t, testGetSLIEventDataWithDefaultStartAndEnd, handler, kClient, rClient, "")
 
 	assertCorrectGetSLIEvents(t, kClient.eventSink, getSLIFinishedEventAssertionsFunc, sliResultAssertionsFunc)
 }

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_usql_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_usql_test.go
@@ -43,7 +43,7 @@ func TestCustomSLIWithIncorrectUSQLQueryPrefix(t *testing.T) {
 
 			// error here: in value of tc.usqlPrefix
 			kClient := &keptnClientMock{
-				customQueries: map[string]string{
+				slis: map[string]string{
 					indicator: tc.usqlPrefix + "SELECT osVersion,AVG(duration) FROM usersession GROUP BY osVersion",
 				},
 			}
@@ -105,7 +105,7 @@ func TestCustomSLIWithCorrectUSQLQueryPrefixMappings(t *testing.T) {
 
 			// errors here: in value of tc.usqlPrefix
 			kClient := &keptnClientMock{
-				customQueries: map[string]string{
+				slis: map[string]string{
 					indicator: tc.usqlPrefix + "SELECT osVersion,AVG(duration) FROM usersession GROUP BY osVersion",
 				},
 			}
@@ -164,7 +164,7 @@ func TestCustomUSQLQueriesReturnsMultipleResults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			kClient := &keptnClientMock{
-				customQueries: map[string]string{
+				slis: map[string]string{
 					indicator: tc.query,
 				},
 			}
@@ -185,7 +185,7 @@ func TestCustomUSQLQueriesReturnsSingleResults(t *testing.T) {
 		"./testdata/usql_200_single_result.json")
 
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "USQL;SINGLE_VALUE;;SELECT AVG(duration) FROM usersession",
 		},
 	}
@@ -204,7 +204,7 @@ func TestCustomUSQLQueriesReturnsNoResults(t *testing.T) {
 		"./testdata/usql_200_0_results.json")
 
 	kClient := &keptnClientMock{
-		customQueries: map[string]string{
+		slis: map[string]string{
 			indicator: "USQL;COLUMN_CHART;iOS 11.4.1;SELECT osVersion,AVG(duration) FROM usersession GROUP BY osVersion",
 		},
 	}
@@ -357,7 +357,7 @@ func TestCustomSLIWithIncorrectUSQLConfiguration(t *testing.T) {
 				tc.dataReturned)
 
 			kClient := &keptnClientMock{
-				customQueries: map[string]string{
+				slis: map[string]string{
 					indicator: tc.usqlQuery,
 				},
 			}

--- a/internal/sli/query/custom_queries.go
+++ b/internal/sli/query/custom_queries.go
@@ -1,0 +1,78 @@
+package query
+
+import "fmt"
+
+const Throughput = "throughput"
+const errorRate = "error_rate"
+const ResponseTimeP50 = "response_time_p50"
+const responseTimeP90 = "response_time_p90"
+const responseTimeP95 = "response_time_p95"
+
+type CustomQueries struct {
+	values map[string]string
+}
+
+func NewEmptyCustomQueries() *CustomQueries {
+	return &CustomQueries{
+		values: make(map[string]string),
+	}
+}
+
+func NewCustomQueries(values map[string]string) *CustomQueries {
+	return &CustomQueries{
+		values: values,
+	}
+}
+
+func (cq *CustomQueries) GetQueryByNameOrDefault(sliName string) (string, error) {
+	query, exists := cq.values[sliName]
+	if exists {
+		return query, nil
+	}
+
+	defaultQuery, err := getDefaultQuery(sliName)
+	if err != nil {
+		return "", err
+	}
+
+	return defaultQuery, nil
+}
+
+func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string, error) {
+	query, exists := cq.values[sliName]
+	if exists {
+		return query, nil
+	}
+
+	// there are custom SLIs defined, but we could not match it
+	if len(cq.values) != 0 {
+		return "", fmt.Errorf("SLI definition for '%s' was not found", sliName)
+	}
+
+	// no custom SLIs defined - so we fallback to using defaults
+	defaultQuery, err := getDefaultQuery(sliName)
+	if err != nil {
+		return "", err
+	}
+
+	return defaultQuery, nil
+}
+
+// based on the requested metric a dynatrace time series with its aggregation type is returned
+func getDefaultQuery(sliName string) (string, error) {
+	// Switched to new metric v2 query language as discussed here: https://github.com/keptn-contrib/dynatrace-sli-service/issues/91
+	switch sliName {
+	case Throughput:
+		return "metricSelector=builtin:service.requestCount.total:merge(\"dt.entity.service\"):sum&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+	case errorRate:
+		return "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+	case ResponseTimeP50:
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+	case responseTimeP90:
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(90)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+	case responseTimeP95:
+		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
+	default:
+		return "", fmt.Errorf("unsupported SLI %s", sliName)
+	}
+}

--- a/internal/sli/query/custom_queries.go
+++ b/internal/sli/query/custom_queries.go
@@ -2,28 +2,32 @@ package query
 
 import "fmt"
 
-const Throughput = "throughput"
+const throughput = "throughput"
 const errorRate = "error_rate"
-const ResponseTimeP50 = "response_time_p50"
+const responseTimeP50 = "response_time_p50"
 const responseTimeP90 = "response_time_p90"
 const responseTimeP95 = "response_time_p95"
 
+// CustomQueries provides access to user-defined or default SLIs.
 type CustomQueries struct {
 	values map[string]string
 }
 
+// NewEmptyCustomQueries creates a new CustomQueries which will only offer default SLIs.
 func NewEmptyCustomQueries() *CustomQueries {
 	return &CustomQueries{
 		values: make(map[string]string),
 	}
 }
 
+// NewCustomQueries creates a new CustomQueries which will offer the specified SLIs as well as defaults.
 func NewCustomQueries(values map[string]string) *CustomQueries {
 	return &CustomQueries{
 		values: values,
 	}
 }
 
+// GetQueryByNameOrDefault returns the custom query with the specified name, a default if available or an error if no such default exists.
 func (cq *CustomQueries) GetQueryByNameOrDefault(sliName string) (string, error) {
 	query, exists := cq.values[sliName]
 	if exists {
@@ -38,6 +42,9 @@ func (cq *CustomQueries) GetQueryByNameOrDefault(sliName string) (string, error)
 	return defaultQuery, nil
 }
 
+// GetQueryByNameOrDefaultIfEmpty returns the custom query with the specified name.
+// If custom queries have been defined, an error will be returned if an entry for name is not included, or
+// if no custom queries have been defined, a default will be returned if available, or an error if no such default exists.
 func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string, error) {
 	query, exists := cq.values[sliName]
 	if exists {
@@ -58,15 +65,14 @@ func (cq *CustomQueries) GetQueryByNameOrDefaultIfEmpty(sliName string) (string,
 	return defaultQuery, nil
 }
 
-// based on the requested metric a dynatrace time series with its aggregation type is returned
 func getDefaultQuery(sliName string) (string, error) {
-	// Switched to new metric v2 query language as discussed here: https://github.com/keptn-contrib/dynatrace-sli-service/issues/91
+	// returns new Metrics v2 queries as discussed here: https://github.com/keptn-contrib/dynatrace-sli-service/issues/91
 	switch sliName {
-	case Throughput:
+	case throughput:
 		return "metricSelector=builtin:service.requestCount.total:merge(\"dt.entity.service\"):sum&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case errorRate:
 		return "metricSelector=builtin:service.errors.total.rate:merge(\"dt.entity.service\"):avg&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
-	case ResponseTimeP50:
+	case responseTimeP50:
 		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(50)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil
 	case responseTimeP90:
 		return "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(90)&entitySelector=type(SERVICE),tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)", nil

--- a/internal/sli/query/custom_queries_test.go
+++ b/internal/sli/query/custom_queries_test.go
@@ -1,4 +1,4 @@
-package keptn
+package query
 
 import "testing"
 

--- a/internal/sli/query/query_processing.go
+++ b/internal/sli/query/query_processing.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	"github.com/keptn-contrib/dynatrace-service/internal/sli/metrics"
 	"github.com/keptn-contrib/dynatrace-service/internal/sli/result"
 	"github.com/keptn-contrib/dynatrace-service/internal/sli/unit"
@@ -29,12 +28,12 @@ type Processing struct {
 	client        dynatrace.ClientInterface
 	eventData     adapter.EventContentAdapter
 	customFilters []*keptnv2.SLIFilter
-	customQueries *keptn.CustomQueries
+	customQueries *CustomQueries
 	timeframe     common.Timeframe
 }
 
 // NewProcessing creates a new Processing.
-func NewProcessing(client dynatrace.ClientInterface, eventData adapter.EventContentAdapter, customFilters []*keptnv2.SLIFilter, customQueries *keptn.CustomQueries, timeframe common.Timeframe) *Processing {
+func NewProcessing(client dynatrace.ClientInterface, eventData adapter.EventContentAdapter, customFilters []*keptnv2.SLIFilter, customQueries *CustomQueries, timeframe common.Timeframe) *Processing {
 	return &Processing{
 		client:        client,
 		eventData:     eventData,

--- a/internal/sli/query/query_processing_test.go
+++ b/internal/sli/query/query_processing_test.go
@@ -198,10 +198,10 @@ func TestGetSLIValueWithOldAndNewCustomQueryFormat(t *testing.T) {
 	for _, testQuery := range testQueries {
 
 		customQueries := make(map[string]string)
-		customQueries[ResponseTimeP50] = testQuery
+		customQueries[responseTimeP50] = testQuery
 
 		p := createCustomQueryProcessing(t, keptnEvent, httpClient, NewCustomQueries(customQueries), timeframe)
-		sliResult := p.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
+		sliResult := p.GetSLIResultFromIndicator(context.TODO(), responseTimeP50)
 
 		assert.True(t, sliResult.Success())
 		assert.InDelta(t, 8.43340, sliResult.Value(), 0.001)
@@ -244,7 +244,7 @@ func runGetSLIResultFromIndicatorTest(t *testing.T, handler http.Handler) result
 
 	dh := createQueryProcessing(t, keptnEvent, httpClient, timeframe)
 
-	return dh.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
+	return dh.GetSLIResultFromIndicator(context.TODO(), responseTimeP50)
 }
 
 // Tests what happens when end time is too close to now. This test results in a short delay.
@@ -286,7 +286,7 @@ func TestGetSLISleep(t *testing.T) {
 
 	// time how long getting the SLI value takes
 	timeBeforeGetSLIValue := time.Now()
-	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
+	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), responseTimeP50)
 	getSLIExectutionTime := time.Since(timeBeforeGetSLIValue)
 
 	assert.True(t, sliResult.Success())
@@ -308,7 +308,7 @@ func TestGetSLIValueWithErrorResponse(t *testing.T) {
 
 	dh := createQueryProcessing(t, keptnEvent, httpClient, timeframe)
 
-	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), Throughput)
+	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), throughput)
 
 	assert.False(t, sliResult.Success())
 	assert.EqualValues(t, 0.0, sliResult.Value())

--- a/internal/sli/query/query_processing_test.go
+++ b/internal/sli/query/query_processing_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/common"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 	"github.com/keptn-contrib/dynatrace-service/internal/sli/result"
 	"github.com/keptn-contrib/dynatrace-service/internal/test"
 
@@ -199,10 +198,10 @@ func TestGetSLIValueWithOldAndNewCustomQueryFormat(t *testing.T) {
 	for _, testQuery := range testQueries {
 
 		customQueries := make(map[string]string)
-		customQueries[keptn.ResponseTimeP50] = testQuery
+		customQueries[ResponseTimeP50] = testQuery
 
-		p := createCustomQueryProcessing(t, keptnEvent, httpClient, keptn.NewCustomQueries(customQueries), timeframe)
-		sliResult := p.GetSLIResultFromIndicator(context.TODO(), keptn.ResponseTimeP50)
+		p := createCustomQueryProcessing(t, keptnEvent, httpClient, NewCustomQueries(customQueries), timeframe)
+		sliResult := p.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
 
 		assert.True(t, sliResult.Success())
 		assert.InDelta(t, 8.43340, sliResult.Value(), 0.001)
@@ -245,7 +244,7 @@ func runGetSLIResultFromIndicatorTest(t *testing.T, handler http.Handler) result
 
 	dh := createQueryProcessing(t, keptnEvent, httpClient, timeframe)
 
-	return dh.GetSLIResultFromIndicator(context.TODO(), keptn.ResponseTimeP50)
+	return dh.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
 }
 
 // Tests what happens when end time is too close to now. This test results in a short delay.
@@ -287,7 +286,7 @@ func TestGetSLISleep(t *testing.T) {
 
 	// time how long getting the SLI value takes
 	timeBeforeGetSLIValue := time.Now()
-	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), keptn.ResponseTimeP50)
+	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), ResponseTimeP50)
 	getSLIExectutionTime := time.Since(timeBeforeGetSLIValue)
 
 	assert.True(t, sliResult.Success())
@@ -309,7 +308,7 @@ func TestGetSLIValueWithErrorResponse(t *testing.T) {
 
 	dh := createQueryProcessing(t, keptnEvent, httpClient, timeframe)
 
-	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), keptn.Throughput)
+	sliResult := dh.GetSLIResultFromIndicator(context.TODO(), Throughput)
 
 	assert.False(t, sliResult.Success())
 	assert.EqualValues(t, 0.0, sliResult.Value())
@@ -349,7 +348,7 @@ func TestGetSLIValueForIndicator(t *testing.T) {
 		customQueries := make(map[string]string)
 		customQueries[testConfig.indicator] = testConfig.query
 
-		ret := createCustomQueryProcessing(t, keptnEvent, httpClient, keptn.NewCustomQueries(customQueries), timeframe)
+		ret := createCustomQueryProcessing(t, keptnEvent, httpClient, NewCustomQueries(customQueries), timeframe)
 
 		sliResult := ret.GetSLIResultFromIndicator(context.TODO(), testConfig.indicator)
 
@@ -375,7 +374,7 @@ func TestGetSLIValueSupportsEnvPlaceholders(t *testing.T) {
 	customQueries := make(map[string]string)
 	customQueries[indicator] = "MV2;MicroSecond;entitySelector=type(SERVICE),tag(\"env_tag:$ENV.MY_ENV_TAG\")&metricSelector=builtin:service.response.time"
 
-	ret := createCustomQueryProcessing(t, keptnEvent, httpClient, keptn.NewCustomQueries(customQueries), timeframe)
+	ret := createCustomQueryProcessing(t, keptnEvent, httpClient, NewCustomQueries(customQueries), timeframe)
 	sliResult := ret.GetSLIResultFromIndicator(context.TODO(), indicator)
 
 	assert.True(t, sliResult.Success())
@@ -455,7 +454,7 @@ func TestGetSLIValueSupportsPlaceholders(t *testing.T) {
 		customQueries := make(map[string]string)
 		customQueries[testConfig.indicator] = testConfig.query
 
-		ret := createCustomQueryProcessing(t, keptnEvent, httpClient, keptn.NewCustomQueries(customQueries), timeframe)
+		ret := createCustomQueryProcessing(t, keptnEvent, httpClient, NewCustomQueries(customQueries), timeframe)
 
 		sliResult := ret.GetSLIResultFromIndicator(context.TODO(), testConfig.indicator)
 
@@ -469,11 +468,11 @@ func createQueryProcessing(t *testing.T, keptnEvent adapter.EventContentAdapter,
 		t,
 		keptnEvent,
 		httpClient,
-		keptn.NewEmptyCustomQueries(),
+		NewEmptyCustomQueries(),
 		timeframe)
 }
 
-func createCustomQueryProcessing(t *testing.T, keptnEvent adapter.EventContentAdapter, httpClient *http.Client, queries *keptn.CustomQueries, timeframe common.Timeframe) *Processing {
+func createCustomQueryProcessing(t *testing.T, keptnEvent adapter.EventContentAdapter, httpClient *http.Client, queries *CustomQueries, timeframe common.Timeframe) *Processing {
 	credentials, err := credentials.NewDynatraceCredentials("http://dynatrace", testDynatraceAPIToken)
 	assert.NoError(t, err)
 

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -257,21 +257,17 @@ func (m *resourceClientMock) GetDashboard(project string, stage string, service 
 }
 
 type keptnClientMock struct {
-	eventSink          []*cloudevents.Event
-	customQueries      map[string]string
-	customQueriesError error
+	eventSink    []*cloudevents.Event
+	slis         map[string]string
+	getSLIsError error
 }
 
-func (m *keptnClientMock) GetCustomQueries(project string, stage string, service string) (*keptn.CustomQueries, error) {
-	if m.customQueriesError != nil {
-		return nil, m.customQueriesError
+func (m *keptnClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
+	if m.getSLIsError != nil {
+		return nil, m.getSLIsError
 	}
 
-	if m.customQueries == nil {
-		return keptn.NewEmptyCustomQueries(), nil
-	}
-
-	return keptn.NewCustomQueries(m.customQueries), nil
+	return m.slis, nil
 }
 
 func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -274,10 +274,6 @@ func (m *keptnClientMock) GetCustomQueries(project string, stage string, service
 	return keptn.NewCustomQueries(m.customQueries), nil
 }
 
-func (m *keptnClientMock) GetShipyard() (*keptnv2.Shipyard, error) {
-	panic("GetShipyard() should not be needed in this mock!")
-}
-
 func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {
 	// simulate errors while creating cloud event
 	if factory == nil {

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -233,7 +233,37 @@ func (e *getSLIEventData) AddLabel(name string, value string) {
 }
 
 type resourceClientMock struct {
-	t *testing.T
+	t            *testing.T
+	slis         map[string]string
+	getSLIsError error
+}
+
+func newResourceClientMock(t *testing.T) *resourceClientMock {
+	return &resourceClientMock{
+		t: t,
+	}
+}
+
+func newResourceClientMockWithSLIs(t *testing.T, slis map[string]string) *resourceClientMock {
+	return &resourceClientMock{
+		t:    t,
+		slis: slis,
+	}
+}
+
+func newResourceClientMockWithGetSLIsError(t *testing.T, getSLIsError error) *resourceClientMock {
+	return &resourceClientMock{
+		t:            t,
+		getSLIsError: getSLIsError,
+	}
+}
+
+func (m *resourceClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
+	if m.getSLIsError != nil {
+		return nil, m.getSLIsError
+	}
+
+	return m.slis, nil
 }
 
 func (m *resourceClientMock) GetSLOs(project string, stage string, service string) (*keptnapi.ServiceLevelObjectives, error) {
@@ -257,17 +287,7 @@ func (m *resourceClientMock) GetDashboard(project string, stage string, service 
 }
 
 type keptnClientMock struct {
-	eventSink    []*cloudevents.Event
-	slis         map[string]string
-	getSLIsError error
-}
-
-func (m *keptnClientMock) GetSLIs(project string, stage string, service string) (map[string]string, error) {
-	if m.getSLIsError != nil {
-		return nil, m.getSLIsError
-	}
-
-	return m.slis, nil
+	eventSink []*cloudevents.Event
 }
 
 func (m *keptnClientMock) SendCloudEvent(factory adapter.CloudEventFactoryInterface) error {


### PR DESCRIPTION
This PR moves `GetSLIs()` and `GetShipyard()` from `keptn.Client` to `keptn.ConfigClient`.