### PR TITLE
feat: add new custom property `evaluationHeatmapURL` to evaluation finished events

### DIFF
--- a/internal/action/action_finished_event_handler.go
+++ b/internal/action/action_finished_event_handler.go
@@ -52,7 +52,7 @@ func (eh *ActionFinishedEventHandler) HandleEvent(workCtx context.Context, _ con
 
 	// https://github.com/keptn-contrib/dynatrace-service/issues/174
 	// Additionally to the problem comment, send Info or Configuration Change Event to the entities in Dynatrace to indicate that remediation actions have been executed
-	customProperties := createCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL)
+	customProperties := NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL)
 	if eh.event.GetStatus() == keptnv2.StatusSucceeded {
 		configurationEvent := dynatrace.ConfigurationEvent{
 			EventType:        dynatrace.ConfigurationEventType,

--- a/internal/action/action_finished_event_handler.go
+++ b/internal/action/action_finished_event_handler.go
@@ -52,7 +52,7 @@ func (eh *ActionFinishedEventHandler) HandleEvent(workCtx context.Context, _ con
 
 	// https://github.com/keptn-contrib/dynatrace-service/issues/174
 	// Additionally to the problem comment, send Info or Configuration Change Event to the entities in Dynatrace to indicate that remediation actions have been executed
-	customProperties := NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL)
+	customProperties := newCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL)
 	if eh.event.GetStatus() == keptnv2.StatusSucceeded {
 		configurationEvent := dynatrace.ConfigurationEvent{
 			EventType:        dynatrace.ConfigurationEventType,

--- a/internal/action/action_triggered_event_handler.go
+++ b/internal/action/action_triggered_event_handler.go
@@ -61,7 +61,7 @@ func (eh *ActionTriggeredEventHandler) HandleEvent(workCtx context.Context, _ co
 		Source:           eventSource,
 		Title:            "Keptn Remediation Action Triggered",
 		Description:      eh.event.GetAction(),
-		CustomProperties: NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL),
+		CustomProperties: newCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL),
 		AttachRules:      *eh.attachRules,
 	}
 

--- a/internal/action/action_triggered_event_handler.go
+++ b/internal/action/action_triggered_event_handler.go
@@ -61,7 +61,7 @@ func (eh *ActionTriggeredEventHandler) HandleEvent(workCtx context.Context, _ co
 		Source:           eventSource,
 		Title:            "Keptn Remediation Action Triggered",
 		Description:      eh.event.GetAction(),
-		CustomProperties: createCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL),
+		CustomProperties: NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), bridgeURL),
 		AttachRules:      *eh.attachRules,
 	}
 

--- a/internal/action/common.go
+++ b/internal/action/common.go
@@ -15,10 +15,10 @@ const bridgeURLKey = "Keptns Bridge"
 
 const contextless = "CONTEXTLESS"
 
-type CustomProperties map[string]string
+type customProperties map[string]string
 
-func NewCustomProperties(a adapter.EventContentAdapter, imageAndTag common.ImageAndTag, bridgeURL string) CustomProperties {
-	cp := CustomProperties{
+func newCustomProperties(a adapter.EventContentAdapter, imageAndTag common.ImageAndTag, bridgeURL string) customProperties {
+	cp := customProperties{
 		"Project":       a.GetProject(),
 		"Stage":         a.GetStage(),
 		"Service":       a.GetService(),
@@ -38,7 +38,7 @@ func NewCustomProperties(a adapter.EventContentAdapter, imageAndTag common.Image
 	return cp
 }
 
-func (cp CustomProperties) add(key string, value string) {
+func (cp customProperties) add(key string, value string) {
 	oldValue, isContained := cp[key]
 	if isContained {
 		log.Warnf("Overwriting current value '%s' of key '%s' with new value '%s in custom properties", oldValue, key, value)
@@ -47,7 +47,7 @@ func (cp CustomProperties) add(key string, value string) {
 	cp[key] = value
 }
 
-func (cp CustomProperties) addIfNonEmpty(key string, value string) {
+func (cp customProperties) addIfNonEmpty(key string, value string) {
 	if key == "" || value == "" {
 		return
 	}

--- a/internal/action/common_test.go
+++ b/internal/action/common_test.go
@@ -1,0 +1,92 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomProperties_Add(t *testing.T) {
+	testConfigs := []struct {
+		name     string
+		key      string
+		value    string
+		expected CustomProperties
+	}{
+		{
+			name:     "both empty",
+			key:      "",
+			value:    "",
+			expected: CustomProperties{"": ""},
+		},
+		{
+			name:     "key empty",
+			key:      "",
+			value:    "value",
+			expected: CustomProperties{"": "value"},
+		},
+		{
+			name:     "value empty",
+			key:      "key",
+			value:    "",
+			expected: CustomProperties{"key": ""},
+		},
+		{
+			name:     "value empty",
+			key:      "key",
+			value:    "value",
+			expected: CustomProperties{"key": "value"},
+		},
+	}
+	for _, testCfg := range testConfigs {
+		t.Run(testCfg.name, func(t *testing.T) {
+			cp := CustomProperties{}
+			cp.add(testCfg.key, testCfg.value)
+
+			assert.Equal(t, testCfg.expected, cp)
+		})
+	}
+}
+
+func TestCustomProperties_AddIfNonEmpty(t *testing.T) {
+
+	testConfigs := []struct {
+		name     string
+		key      string
+		value    string
+		expected CustomProperties
+	}{
+		{
+			name:     "both empty",
+			key:      "",
+			value:    "",
+			expected: CustomProperties{},
+		},
+		{
+			name:     "key empty",
+			key:      "",
+			value:    "value",
+			expected: CustomProperties{},
+		},
+		{
+			name:     "value empty",
+			key:      "key",
+			value:    "",
+			expected: CustomProperties{},
+		},
+		{
+			name:     "value empty",
+			key:      "key",
+			value:    "value",
+			expected: CustomProperties{"key": "value"},
+		},
+	}
+	for _, testCfg := range testConfigs {
+		t.Run(testCfg.name, func(t *testing.T) {
+			cp := CustomProperties{}
+			cp.addIfNonEmpty(testCfg.key, testCfg.value)
+
+			assert.Equal(t, testCfg.expected, cp)
+		})
+	}
+}

--- a/internal/action/common_test.go
+++ b/internal/action/common_test.go
@@ -11,36 +11,36 @@ func TestCustomProperties_Add(t *testing.T) {
 		name     string
 		key      string
 		value    string
-		expected CustomProperties
+		expected customProperties
 	}{
 		{
 			name:     "both empty",
 			key:      "",
 			value:    "",
-			expected: CustomProperties{"": ""},
+			expected: customProperties{"": ""},
 		},
 		{
 			name:     "key empty",
 			key:      "",
 			value:    "value",
-			expected: CustomProperties{"": "value"},
+			expected: customProperties{"": "value"},
 		},
 		{
 			name:     "value empty",
 			key:      "key",
 			value:    "",
-			expected: CustomProperties{"key": ""},
+			expected: customProperties{"key": ""},
 		},
 		{
 			name:     "value empty",
 			key:      "key",
 			value:    "value",
-			expected: CustomProperties{"key": "value"},
+			expected: customProperties{"key": "value"},
 		},
 	}
 	for _, testCfg := range testConfigs {
 		t.Run(testCfg.name, func(t *testing.T) {
-			cp := CustomProperties{}
+			cp := customProperties{}
 			cp.add(testCfg.key, testCfg.value)
 
 			assert.Equal(t, testCfg.expected, cp)
@@ -54,36 +54,36 @@ func TestCustomProperties_AddIfNonEmpty(t *testing.T) {
 		name     string
 		key      string
 		value    string
-		expected CustomProperties
+		expected customProperties
 	}{
 		{
 			name:     "both empty",
 			key:      "",
 			value:    "",
-			expected: CustomProperties{},
+			expected: customProperties{},
 		},
 		{
 			name:     "key empty",
 			key:      "",
 			value:    "value",
-			expected: CustomProperties{},
+			expected: customProperties{},
 		},
 		{
 			name:     "value empty",
 			key:      "key",
 			value:    "",
-			expected: CustomProperties{},
+			expected: customProperties{},
 		},
 		{
 			name:     "value empty",
 			key:      "key",
 			value:    "value",
-			expected: CustomProperties{"key": "value"},
+			expected: customProperties{"key": "value"},
 		},
 	}
 	for _, testCfg := range testConfigs {
 		t.Run(testCfg.name, func(t *testing.T) {
-			cp := CustomProperties{}
+			cp := customProperties{}
 			cp.addIfNonEmpty(testCfg.key, testCfg.value)
 
 			assert.Equal(t, testCfg.expected, cp)

--- a/internal/action/deployment_finished_event_handler.go
+++ b/internal/action/deployment_finished_event_handler.go
@@ -41,7 +41,7 @@ func (eh *DeploymentFinishedEventHandler) HandleEvent(workCtx context.Context, _
 		DeploymentVersion: getValueFromLabels(eh.event, "deploymentVersion", imageAndTag.Tag()),
 		CiBackLink:        getValueFromLabels(eh.event, "ciBackLink", ""),
 		RemediationAction: getValueFromLabels(eh.event, "remediationAction", ""),
-		CustomProperties:  createCustomProperties(eh.event, imageAndTag, keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:  NewCustomProperties(eh.event, imageAndTag, keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:       *eh.attachRules,
 	}
 

--- a/internal/action/deployment_finished_event_handler.go
+++ b/internal/action/deployment_finished_event_handler.go
@@ -41,7 +41,7 @@ func (eh *DeploymentFinishedEventHandler) HandleEvent(workCtx context.Context, _
 		DeploymentVersion: getValueFromLabels(eh.event, "deploymentVersion", imageAndTag.Tag()),
 		CiBackLink:        getValueFromLabels(eh.event, "ciBackLink", ""),
 		RemediationAction: getValueFromLabels(eh.event, "remediationAction", ""),
-		CustomProperties:  NewCustomProperties(eh.event, imageAndTag, keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:  newCustomProperties(eh.event, imageAndTag, keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:       *eh.attachRules,
 	}
 

--- a/internal/action/evaluation_finished_event_handler.go
+++ b/internal/action/evaluation_finished_event_handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/keptn-contrib/dynatrace-service/internal/keptn"
 )
 
+const evaluationURLKey = "evaluationHeatmapURL"
+
 // EvaluationFinishedEventHandler handles an evaluation finished event.
 type EvaluationFinishedEventHandler struct {
 	event       EvaluationFinishedAdapterInterface
@@ -54,12 +56,16 @@ func (eh *EvaluationFinishedEventHandler) HandleEvent(workCtx context.Context, _
 		return fmt.Errorf("could not setup correct attach rules: %w", err)
 	}
 
+	evaluationURL := keptn.TryGetBridgeURLForEvaluation(workCtx, eh.event)
+	customProperties := NewCustomProperties(eh.event, imageAndTag, bridgeURL)
+	customProperties.addIfNonEmpty(evaluationURLKey, evaluationURL)
+
 	infoEvent := dynatrace.InfoEvent{
 		EventType:        dynatrace.InfoEventType,
 		Source:           eventSource,
 		Title:            eh.getTitle(isPartOfRemediation),
 		Description:      fmt.Sprintf("Quality Gate Result in stage %s: %s (%.2f/100)", eh.event.GetStage(), eh.event.GetResult(), eh.event.GetEvaluationScore()),
-		CustomProperties: createCustomProperties(eh.event, imageAndTag, bridgeURL),
+		CustomProperties: customProperties,
 		AttachRules:      attachRules,
 	}
 

--- a/internal/action/evaluation_finished_event_handler.go
+++ b/internal/action/evaluation_finished_event_handler.go
@@ -57,7 +57,7 @@ func (eh *EvaluationFinishedEventHandler) HandleEvent(workCtx context.Context, _
 	}
 
 	evaluationURL := keptn.TryGetBridgeURLForEvaluation(workCtx, eh.event)
-	customProperties := NewCustomProperties(eh.event, imageAndTag, bridgeURL)
+	customProperties := newCustomProperties(eh.event, imageAndTag, bridgeURL)
 	customProperties.addIfNonEmpty(evaluationURLKey, evaluationURL)
 
 	infoEvent := dynatrace.InfoEvent{

--- a/internal/action/evaluation_finished_event_handler.go
+++ b/internal/action/evaluation_finished_event_handler.go
@@ -56,9 +56,8 @@ func (eh *EvaluationFinishedEventHandler) HandleEvent(workCtx context.Context, _
 		return fmt.Errorf("could not setup correct attach rules: %w", err)
 	}
 
-	evaluationURL := keptn.TryGetBridgeURLForEvaluation(workCtx, eh.event)
 	customProperties := newCustomProperties(eh.event, imageAndTag, bridgeURL)
-	customProperties.addIfNonEmpty(evaluationURLKey, evaluationURL)
+	customProperties.addIfNonEmpty(evaluationURLKey, keptn.TryGetBridgeURLForEvaluation(workCtx, eh.event))
 
 	infoEvent := dynatrace.InfoEvent{
 		EventType:        dynatrace.InfoEventType,

--- a/internal/action/release_triggered_event_handler.go
+++ b/internal/action/release_triggered_event_handler.go
@@ -46,7 +46,7 @@ func (eh *ReleaseTriggeredEventHandler) HandleEvent(workCtx context.Context, _ c
 		Source:           eventSource,
 		Title:            eh.getTitle(strategy, eh.event.GetLabels()["title"]),
 		Description:      eh.getTitle(strategy, eh.event.GetLabels()["description"]),
-		CustomProperties: createCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties: NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:      *eh.attachRules,
 	}
 

--- a/internal/action/release_triggered_event_handler.go
+++ b/internal/action/release_triggered_event_handler.go
@@ -46,7 +46,7 @@ func (eh *ReleaseTriggeredEventHandler) HandleEvent(workCtx context.Context, _ c
 		Source:           eventSource,
 		Title:            eh.getTitle(strategy, eh.event.GetLabels()["title"]),
 		Description:      eh.getTitle(strategy, eh.event.GetLabels()["description"]),
-		CustomProperties: NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties: newCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:      *eh.attachRules,
 	}
 

--- a/internal/action/test_finished_event_handler.go
+++ b/internal/action/test_finished_event_handler.go
@@ -35,7 +35,7 @@ func (eh *TestFinishedEventHandler) HandleEvent(workCtx context.Context, _ conte
 		Source:                eventSource,
 		AnnotationType:        getValueFromLabels(eh.event, "type", "Stop Tests"),
 		AnnotationDescription: getValueFromLabels(eh.event, "description", "Stop running tests: against "+eh.event.GetService()),
-		CustomProperties:      NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:      newCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:           *eh.attachRules,
 	}
 

--- a/internal/action/test_finished_event_handler.go
+++ b/internal/action/test_finished_event_handler.go
@@ -35,7 +35,7 @@ func (eh *TestFinishedEventHandler) HandleEvent(workCtx context.Context, _ conte
 		Source:                eventSource,
 		AnnotationType:        getValueFromLabels(eh.event, "type", "Stop Tests"),
 		AnnotationDescription: getValueFromLabels(eh.event, "description", "Stop running tests: against "+eh.event.GetService()),
-		CustomProperties:      createCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:      NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:           *eh.attachRules,
 	}
 

--- a/internal/action/test_triggered_event_handler.go
+++ b/internal/action/test_triggered_event_handler.go
@@ -36,7 +36,7 @@ func (eh *TestTriggeredEventHandler) HandleEvent(workCtx context.Context, _ cont
 		Source:                eventSource,
 		AnnotationType:        getValueFromLabels(eh.event, "type", "Start Tests: "+eh.event.GetTestStrategy()),
 		AnnotationDescription: getValueFromLabels(eh.event, "description", "Start running tests: "+eh.event.GetTestStrategy()+" against "+eh.event.GetService()),
-		CustomProperties:      createCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:      NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:           *eh.attachRules,
 	}
 

--- a/internal/action/test_triggered_event_handler.go
+++ b/internal/action/test_triggered_event_handler.go
@@ -36,7 +36,7 @@ func (eh *TestTriggeredEventHandler) HandleEvent(workCtx context.Context, _ cont
 		Source:                eventSource,
 		AnnotationType:        getValueFromLabels(eh.event, "type", "Start Tests: "+eh.event.GetTestStrategy()),
 		AnnotationDescription: getValueFromLabels(eh.event, "description", "Start running tests: "+eh.event.GetTestStrategy()+" against "+eh.event.GetService()),
-		CustomProperties:      NewCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
+		CustomProperties:      newCustomProperties(eh.event, eh.eClient.GetImageAndTag(workCtx, eh.event), keptn.TryGetBridgeURLForKeptnContext(workCtx, eh.event)),
 		AttachRules:           *eh.attachRules,
 	}
 

--- a/internal/keptn/common.go
+++ b/internal/keptn/common.go
@@ -2,6 +2,7 @@ package keptn
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/keptn-contrib/dynatrace-service/internal/adapter"
 	"github.com/keptn-contrib/dynatrace-service/internal/credentials"
@@ -11,19 +12,34 @@ import (
 	v2 "github.com/keptn/go-utils/pkg/api/utils/v2"
 )
 
-// TryGetBridgeURLForKeptnContext gets a backlink to the Keptn Bridge if available or returns "".
+// TryGetBridgeURLForKeptnContext gets a backlink to the Keptn Bridge if available or returns empty string.
 func TryGetBridgeURLForKeptnContext(ctx context.Context, event adapter.EventContentAdapter) string {
-	credentials, err := credentials.GetKeptnCredentials(ctx)
-	if err != nil {
-		return ""
-	}
-
-	keptnBridgeURL := credentials.GetBridgeURL()
+	keptnBridgeURL := tryGetBridgeURL(ctx)
 	if keptnBridgeURL == "" {
 		return ""
 	}
 
 	return keptnBridgeURL + "/trace/" + event.GetShKeptnContext()
+}
+
+// tryGetBridgeURL gets the Keptn Bridge URL if available or returns empty string.
+func tryGetBridgeURL(ctx context.Context) string {
+	creds, err := credentials.GetKeptnCredentials(ctx)
+	if err != nil {
+		return ""
+	}
+
+	return creds.GetBridgeURL()
+}
+
+// TryGetBridgeURLForEvaluation gets a backlink to the evaluation in Keptn Bridge if available or returns empty string.
+func TryGetBridgeURLForEvaluation(ctx context.Context, event adapter.EventContentAdapter) string {
+	keptnBridgeURL := tryGetBridgeURL(ctx)
+	if keptnBridgeURL == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/evaluation/%s/%s", keptnBridgeURL, event.GetShKeptnContext(), event.GetStage())
 }
 
 // GetV1InClusterAPIMappings returns the InClusterAPIMappings.


### PR DESCRIPTION
This PR will add a new custom property `evaluationHeatmapURL` with the direct back link to the evaluation page in Keptn Bridge

relates to #240 