### PR TITLE
ci: remove distributor version from in release actions

### DIFF
--- a/.github/workflows/build-helm-chart.yml
+++ b/.github/workflows/build-helm-chart.yml
@@ -9,10 +9,6 @@ on:
       version:
         type: string
         required: true
-      distributor-version:
-        description: "The version of the distributor, that will be used in values.yml"
-        type: string
-        required: true
       datetime:
         type: string
         required: false
@@ -39,7 +35,6 @@ jobs:
       VERSION: ${{ inputs.version }}
       DATETIME: ${{ inputs.datetime }}
       RELEASE_BUILD: ${{ inputs.release }}
-      DISTRIBUTOR_VERSION: ${{ inputs.distributor-version  }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3.0.2
@@ -56,10 +51,10 @@ jobs:
         run: |
           if [[ "$BRANCH" == "master" ]] && [[ "$RELEASE_BUILD" == 'false' ]] && [[ $DATETIME != "" ]]; then
             # use VERSION.DATETIME for the image tag (e.g., nightly build)
-            ./gh-actions-scripts/build_helm_chart.sh "${VERSION}" "${VERSION}.${DATETIME}" "${IMAGE}" "${DISTRIBUTOR_VERSION}"
+            ./gh-actions-scripts/build_helm_chart.sh "${VERSION}" "${VERSION}.${DATETIME}" "${IMAGE}"
           else
             # just use VERSION for the image tag
-            ./gh-actions-scripts/build_helm_chart.sh "${VERSION}" "${VERSION}" "${IMAGE}" "${DISTRIBUTOR_VERSION}"
+            ./gh-actions-scripts/build_helm_chart.sh "${VERSION}" "${VERSION}" "${IMAGE}"
           fi
 
       - name: Upload Helm Chart as an artifact

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,10 +5,7 @@ on:
       semver-type:
         description: "Can be one of [major,minor,patch]. CAUTION: This will enforce a new pre-release with the specified semantic version type bumped."
         required: false
-      keptn-version:
-        description: "The current Keptn version that this release shall be used with. This version also determines the value for the Distributor version in values.yml"
-        required: true
-        type: string
+
 env:
   NODE_VERSION: 14
   KEPTN_BOT_NAME: "Keptn Contrib Bot"
@@ -135,7 +132,6 @@ jobs:
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}
-      distributor-version: ${{ github.event.inputs.keptn-version }}
       release: true
 
   ############################################################################

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -128,7 +128,7 @@ jobs:
   build-helm-chart:
     needs: prepare
     name: Build Helm Charts
-    uses: keptn-contrib/dynatrace-service/.github/workflows/build-helm-chart.yml@master
+    uses: ./.github/workflows/build-helm-chart.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
   build-helm-chart:
     needs: prepare
     name: Build Helm Charts
-    uses: keptn-contrib/dynatrace-service/.github/workflows/build-helm-chart.yml@master
+    uses: ./.github/workflows/build-helm-chart.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
       keptn-version:
-        description: "The version of Keptn this release has been tested with. This version also determines the value for the Distributor version in values.yml and will be included in all compatibility updates. E.g. `0.11.3`"
+        description: "The version of Keptn this release has been tested with. This will be included in all compatibility updates. E.g. `0.11.3`"
         required: true
         type: string
       dynatrace-version:
@@ -154,7 +154,6 @@ jobs:
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}
-      distributor-version: ${{ github.event.inputs.keptn-version }}
       release: true
 
   ############################################################################

--- a/gh-actions-scripts/build_helm_chart.sh
+++ b/gh-actions-scripts/build_helm_chart.sh
@@ -4,10 +4,9 @@
 VERSION=$1
 IMAGE_TAG=$2
 IMAGE=$3
-DISTRIBUTOR_VERSION=$4
 
-if [ $# -ne 4 ]; then
-  echo "Usage: $0 VERSION IMAGE_TAG IMAGE DISTRIBUTOR_VERSION"
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 VERSION IMAGE_TAG IMAGE"
   exit
 fi
 
@@ -21,18 +20,11 @@ if [ -z "$IMAGE_TAG" ]; then
   IMAGE_TAG=$VERSION
 fi
 
-if [ -z "$DISTRIBUTOR_VERSION" ]; then
-  echo "No Distributor version set, exiting..."
-  exit 1
-fi
-
 
 # replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
 IT="$IMAGE_TAG" yq e -i '.appVersion = strenv(IT)' ./chart/Chart.yaml
 V="$VERSION" yq e -i '.version = strenv(V)' ./chart/Chart.yaml
 
-# replace distributor version in 'values.yaml'
-DV="$DISTRIBUTOR_VERSION" yq e -i '.distributor.image.tag = strenv(DV)' ./chart/values.yaml
 
 mkdir installer/
 


### PR DESCRIPTION
we do no longer need the distributor version in `values.yaml` so this has been removed