### PR TITLE
fix: Make K8S_NAMESPACE and K8S_NODE_NAME configurable for cp-connector

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,15 +62,23 @@ spec:
                   apiVersion: v1
                   fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
             - name: K8S_NAMESPACE
+            {{- if .Values.distributor.metadata.namespace }}
+              value: {{ .Values.distributor.metadata.namespace }}
+            {{- else }}
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            {{- end }}
             - name: K8S_NODE_NAME
+            {{- if .Values.distributor.metadata.hostname }}
+              value: {{ .Values.distributor.metadata.hostname }}
+            {{- else }}
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- end }}            
             - name: K8S_POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,6 +41,11 @@ securityContext:                             # Set the security context (e.g. ru
   seccompProfile:
       type: RuntimeDefault
 
+distributor:
+  metadata:
+    hostname: ""                             # Sets the hostname sent by the distributor to the control-plane
+    namespace: ""                            # Sets the namespace sent by the distributor to the control-plane
+
 resources:                                  # Set resources limits and requests
   limits:
     cpu: 128m


### PR DESCRIPTION
This PR will add the missing Environment Variables to the cp-connection configuration to overwrite `K8S_NODE_NAME` and `K8S_NAMESPACE` default settings.