### PR TITLE
feat!: Remove automatic conversion of `builtin:service.response.time` as well as microsecond and byte units

### DIFF
--- a/documentation/sli-provider.md
+++ b/documentation/sli-provider.md
@@ -9,6 +9,9 @@ The mode selected by the dynatrace-service depends on the value of the `dashboar
 
 To help you understand the queries used for obtaining the SLIs, the dynatrace-service includes a custom `query` field in each element of `indicatorValues` in the `sh.keptn.event.get-sli.finished` event. This consists of the path and query string of the associated API request and is viewable directly in the Event payload in the Bridge. 
 
+## Specifying the units of SLIs based on the Metrics v2 API 
+The dynatrace-service always returns SLIs in the same units as the underlying metric expression. To convert between units, append a [`:toUnit(<sourceUnit>,<targetUnit>)` transformation](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/metric-selector#to-unit) to the metric expression (e.g. in the **Code** tab of the Data Explorer). For example, `builtin:service.response.time:toUnit(MicroSecond,MilliSecond)` will produce a service response time metric in milliseconds. Alternatively, for file-based SLIs, the [`MV2` prefix](slis-via-files.md#converted-metrics-prefix-mv2) may be used to convert microseconds to milliseconds or bytes to kilobytes in a concise way. For example, `MV2;MicroSecond;metricSelector=builtin:service.response.time:splitBy():avg&entitySelector=type(SERVICE)` will convert the `builtin:service.response.time` metric from microseconds to milliseconds.
+
 ## SLI evaluation in auto-remediation workflows
 
 As part of its auto-remediation sequence, Keptn also evaluates SLOs after executing the remediation action. By default, the auto-remediation workflow can be terminated if and only if the problem has been closed in Dynatrace.

--- a/internal/sli/dashboard/custom_charting_tile_processing.go
+++ b/internal/sli/dashboard/custom_charting_tile_processing.go
@@ -168,7 +168,6 @@ func (p *CustomChartingTileProcessing) generateMetricQueryFromChartSeries(ctx co
 	return &queryComponents{
 		metricsQuery: *metricsQuery,
 		timeframe:    p.timeframe,
-		metricUnit:   metricDefinition.Unit,
 	}, nil
 }
 

--- a/internal/sli/dashboard/data_explorer_tile_processing.go
+++ b/internal/sli/dashboard/data_explorer_tile_processing.go
@@ -159,7 +159,6 @@ func (p *DataExplorerTileProcessing) generateMetricQueryFromDataExplorerQuery(ct
 	return &queryComponents{
 		metricsQuery: *metricsQuery,
 		timeframe:    p.timeframe,
-		metricUnit:   metricDefinition.Unit,
 	}, nil
 
 }

--- a/internal/sli/dashboard/metric_query_components.go
+++ b/internal/sli/dashboard/metric_query_components.go
@@ -8,5 +8,4 @@ import (
 type queryComponents struct {
 	metricsQuery metrics.Query
 	timeframe    common.Timeframe
-	metricUnit   string
 }

--- a/internal/sli/dashboard/metrics_query_processing.go
+++ b/internal/sli/dashboard/metrics_query_processing.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/keptn-contrib/dynatrace-service/internal/dynatrace"
-	"github.com/keptn-contrib/dynatrace-service/internal/sli/unit"
 	keptncommon "github.com/keptn/go-utils/pkg/lib"
 	log "github.com/sirupsen/logrus"
 )
@@ -91,9 +90,6 @@ func (r *MetricsQueryProcessing) processSingleResult(noOfDimensionsInChart int, 
 			value = value + singleValue
 		}
 		value = value / float64(len(singleDataEntry.Values))
-
-		// lets scale the metric
-		value = unit.ScaleData(metricQueryComponents.metricUnit, value)
 
 		// we got our metric, SLOs and the value
 		log.WithFields(

--- a/internal/sli/dashboard/metrics_query_processing.go
+++ b/internal/sli/dashboard/metrics_query_processing.go
@@ -93,7 +93,7 @@ func (r *MetricsQueryProcessing) processSingleResult(noOfDimensionsInChart int, 
 		value = value / float64(len(singleDataEntry.Values))
 
 		// lets scale the metric
-		value = unit.ScaleData(metricQueryComponents.metricsQuery.GetMetricSelector(), metricQueryComponents.metricUnit, value)
+		value = unit.ScaleData(metricQueryComponents.metricUnit, value)
 
 		// we got our metric, SLOs and the value
 		log.WithFields(

--- a/internal/sli/dashboard/metrics_query_processing_test.go
+++ b/internal/sli/dashboard/metrics_query_processing_test.go
@@ -45,12 +45,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:service.response.client:merge(\"dt.entity.service\"):avg:names", "type(SERVICE)"),
-					metricUnit:   "MicroSecond",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("csrt", 15.868648438045174, "/api/v2/metrics/query?entitySelector=type%28SERVICE%29&from=1633420800000&metricSelector=builtin%3Aservice.response.client%3Amerge%28%22dt.entity.service%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("csrt", 15868.648438045173, "/api/v2/metrics/query?entitySelector=type%28SERVICE%29&from=1633420800000&metricSelector=builtin%3Aservice.response.client%3Amerge%28%22dt.entity.service%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "csrt",
 					Weight: 1,
@@ -70,12 +69,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:containers.memory_usage2:merge(\"container_id\"):merge(\"dt.entity.docker_container_group_instance\"):avg:names", "type(DOCKER_CONTAINER_GROUP_INSTANCE)"),
-					metricUnit:   "Byte",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 48975.83345935025, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "cmu",
 					Weight: 1,
@@ -95,7 +93,6 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:host.dns.queryCount:merge(\"dnsServerIp\"):merge(\"dt.entity.host\"):avg:names", "type(HOST)"),
-					metricUnit:   "Count",
 					timeframe:    *timeframe,
 				},
 			},
@@ -122,12 +119,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:containers.memory_usage2:merge(\"container_id\"):merge(\"dt.entity.docker_container_group_instance\"):avg:names", "type(DOCKER_CONTAINER_GROUP_INSTANCE)"),
-					metricUnit:   "Byte",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466/1024, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "cmu",
 					Weight: 1,
@@ -148,12 +144,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				metricQueryComponents: &queryComponents{
 
 					metricsQuery: createMetricsQuery(t, "builtin:containers.memory_usage2:merge(container_id):merge(dt.entity.docker_container_group_instance):avg:names", "type(DOCKER_CONTAINER_GROUP_INSTANCE)"),
-					metricUnit:   "Byte",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 48975.83345935025, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28container_id%29%3Amerge%28dt.entity.docker_container_group_instance%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28container_id%29%3Amerge%28dt.entity.docker_container_group_instance%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "cmu",
 					Weight: 1,
@@ -173,12 +168,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:containers.memory_usage2:merge(container_id):merge(\"dt.entity.docker_container_group_instance\"):avg:names", "type(DOCKER_CONTAINER_GROUP_INSTANCE)"),
-					metricUnit:   "Byte",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 48975.83345935025, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28container_id%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28container_id%29%3Amerge%28%22dt.entity.docker_container_group_instance%22%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "cmu",
 					Weight: 1,
@@ -198,12 +192,11 @@ func TestMetricsQueryProcessing_Process(t *testing.T) {
 				},
 				metricQueryComponents: &queryComponents{
 					metricsQuery: createMetricsQuery(t, "builtin:containers.memory_usage2:merge(\"container_id\"):merge(dt.entity.docker_container_group_instance):avg:names", "type(DOCKER_CONTAINER_GROUP_INSTANCE)"),
-					metricUnit:   "Byte",
 					timeframe:    *timeframe,
 				},
 			},
 			expectedTileResult: TileResult{
-				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 48975.83345935025, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28dt.entity.docker_container_group_instance%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
+				sliResult: result.NewSuccessfulSLIResultWithQuery("cmu", 50151253.46237466, "/api/v2/metrics/query?entitySelector=type%28DOCKER_CONTAINER_GROUP_INSTANCE%29&from=1633420800000&metricSelector=builtin%3Acontainers.memory_usage2%3Amerge%28%22container_id%22%29%3Amerge%28dt.entity.docker_container_group_instance%29%3Aavg%3Anames&resolution=Inf&to=1633507200000"),
 				sloDefinition: &keptncommon.SLO{
 					SLI:    "cmu",
 					Weight: 1,

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_custom_charting_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_custom_charting_test.go
@@ -20,10 +20,10 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_SplitByServiceKeyRequest
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_get_by_query_builtin_servicekeyrequest_totalprocessingtime.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("processing_time_findlocations", 18.22756816390859, expectedMetricsRequest),
-		createSuccessfulSLIResultAssertionsFunc("processing_time_getjourneybyid", 2.8606086572438163, expectedMetricsRequest),
-		createSuccessfulSLIResultAssertionsFunc("processing_time_getjourneypagebytenant", 15.964052631578946, expectedMetricsRequest),
-		createSuccessfulSLIResultAssertionsFunc("processing_time_findjourneys", 23.587584492453388, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("processing_time_findlocations", 18227.56816390859, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("processing_time_getjourneybyid", 2860.6086572438163, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("processing_time_getjourneypagebytenant", 15964.052631578946, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("processing_time_findjourneys", 23587.584492453388, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -65,7 +65,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_NoSplitByNoFilterBy(t *t
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_get_by_query_builtin_service_responsetime.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("service_response_time", 29.31312208863131, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("service_response_time", 29313.12208863131, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -96,8 +96,8 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_SplitByServiceFilterByAu
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_get_by_query_builtin_service_responsetime.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_autotags_easytravelservice", 132.27823461853978, expectedMetricsRequest),
-		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_autotags_journeyservice", 20.256493055555555, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_autotags_easytravelservice", 132278.23461853978, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_autotags_journeyservice", 20256.493055555555, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -116,7 +116,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_SplitByServiceFilterBySp
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_get_by_query_builtin_service_responsetime.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_specificentity", 20.256493055555555, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("services_response_time_splitby_service_filterby_specificentity", 20256.493055555555, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -162,7 +162,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_OldTest_ResponseTimeP90(
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_p90.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("svc_rt_p90", 35.00002454848894, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("svc_rt_p90", 35000.02454848894, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -179,7 +179,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_OldTest_ResponseTimeP50(
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_p50.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("svc_rt_p50", 1.500151733421778, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("svc_rt_p50", 1500.151733421778, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -196,7 +196,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_OldTest_ProcessMemoryAvg
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_tech_generic_mem_workingsetsize_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("process_memory", 1437907.0484235594, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("process_memory", 1472416817.5857248, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -317,7 +317,7 @@ func TestRetrieveMetricsFromDashboardCustomChartingTile_ExcludedTile(t *testing.
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_get_by_query_builtin_service_responsetime.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("service_response_time", 29.31312208863131, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("service_response_time", 29313.12208863131, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
@@ -87,7 +87,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgNoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_avg", 29.192929640271974, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_avg", 29192.929640271974, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -106,7 +106,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgCountNoFilterBy(t *
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_count.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_count", 1060428.829, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_count", 1060428829, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -125,7 +125,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgMaxNoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_max.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_max", 45156.016, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_max", 45156016, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -144,7 +144,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgMedianNoFilterBy(t 
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_median.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_median", 1.4999996049587276, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_median", 1499.9996049587276, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -182,7 +182,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgP10NoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_p10.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_p10", 1.0000048892760918, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_p10", 1000.0048892760917, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -201,7 +201,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgP75NoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_p75.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_p75", 3.2541557923119475, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_p75", 3254.1557923119476, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -220,7 +220,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgp90NoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_p90.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_p90", 35.00000424055808, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_p90", 35000.004240558075, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -239,7 +239,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgSumNoFilterBy(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_sum.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_sum", 30957024193.513, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_sum", 30957024193513, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -271,7 +271,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgFilterById(t *te
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_jid", 136.52852484946527, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_jid", 136528.52484946526, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -290,7 +290,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgFilterByTag(t *t
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_keptn_manager", 18.533351299277793, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_keptn_manager", 18533.351299277794, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -309,7 +309,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgFilterByEntityAt
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_svc_etw_db", 1.0706877628404, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_svc_etw_db", 1070.6877628404, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -328,7 +328,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgFilterByDimensio
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_calc_service_dbcalls_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("svc_db_calls", 0.005373592355230029, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("svc_db_calls", 5.37359235523003, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -360,7 +360,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_NoFilter_NoManagementZone(
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt_no_filter_no_mz", 29.192929640271974, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt_no_filter_no_mz", 29192.929640271974, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -379,7 +379,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_ServiceTag_Filter_NoManage
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt_servicetag_filter_no_mz", 288.95723558253565, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt_servicetag_filter_no_mz", 288957.2355825356, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -398,7 +398,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_NoFilter_WithCustomManagem
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt_no_filter_custom_mz", 7.045031103506126, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt_no_filter_custom_mz", 7045.031103506126, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -417,7 +417,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_ServiceTag_Filter_WithCust
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt_servicetag_filter_custom_mz", 8.283891270010905, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt_servicetag_filter_custom_mz", 8283.891270010905, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
@@ -449,7 +449,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_CustomSLO(t *testing.T) {
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt", 29.192929640271974, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt", 29192.929640271974, expectedMetricsRequest),
 	}
 
 	uploadedSLOsAssertionsFunc := func(t *testing.T, actual *keptn.ServiceLevelObjectives) {
@@ -481,7 +481,7 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_ExcludedTile(t *testing.T)
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_avg.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("rt_jid", 136.52852484946527, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("rt_jid", 136528.52484946526, expectedMetricsRequest),
 	}
 
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_slo_generation_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_slo_generation_test.go
@@ -21,7 +21,7 @@ func TestRetrieveMetrics_SLOObjectiveGeneratedFromSupportedDataExplorerTile(t *t
 	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time.json")
 
 	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
-		createSuccessfulSLIResultAssertionsFunc("srt", 29.192929640271974, expectedMetricsRequest),
+		createSuccessfulSLIResultAssertionsFunc("srt", 29192.929640271974, expectedMetricsRequest),
 	}
 
 	uploadedSLOsAssertionsFunc := func(t *testing.T, actual *keptnapi.ServiceLevelObjectives) {

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_test.go
@@ -35,7 +35,7 @@ func TestNoErrorIsReturnedWhenSLOFileWritingSucceeds(t *testing.T) {
 		t: t,
 	}
 
-	runAndAssertThatDashboardTestIsCorrect(t, testGetSLIEventData, handler, resourceClientMock, getSLIFinishedEventAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12.439619479902443, expectedMetricsRequest))
+	runAndAssertThatDashboardTestIsCorrect(t, testGetSLIEventData, handler, resourceClientMock, getSLIFinishedEventAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12439.619479902443, expectedMetricsRequest))
 }
 
 // TestErrorIsReturnedWhenSLOFileWritingFails tests that an error is returned if retrieving (a single) SLI from a dashboard works but upload of SLO file fails.
@@ -85,7 +85,7 @@ func TestThatThereIsNoFallbackToSLIsFromDashboard(t *testing.T) {
 	rClient := &uploadErrorResourceClientMock{t: t}
 
 	// value is divided by 1000 from dynatrace API result!
-	runAndAssertThatDashboardTestIsCorrect(t, testGetSLIEventData, handler, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12.439619479902443, expectedMetricsRequest))
+	runAndAssertThatDashboardTestIsCorrect(t, testGetSLIEventData, handler, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12439.619479902443, expectedMetricsRequest))
 	assert.True(t, rClient.slosUploaded)
 }
 

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_sli_files_metrics_query_test.go
@@ -148,7 +148,7 @@ func TestNoDefaultSLIsAreUsedWhenCustomSLIsAreDefinedButEmpty(t *testing.T) {
 	// TODO 2021-09-29: we should be able to differentiate between 'not there' and 'no SLIs defined' - the latter could be intentional
 	rClient := newResourceClientMock(t)
 
-	assertThatCustomSLITestIsCorrect(t, handler, testIndicatorResponseTimeP95, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12.439619479902443, expectedMetricsRequest))
+	assertThatCustomSLITestIsCorrect(t, handler, testIndicatorResponseTimeP95, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12439.619479902443, expectedMetricsRequest))
 }
 
 // In case we do not use the dashboard for defining SLIs we can use the file 'dynatrace/sli.yaml'.
@@ -165,5 +165,5 @@ func TestCustomSLIsAreUsedWhenSpecified(t *testing.T) {
 		testIndicatorResponseTimeP95: "metricSelector=builtin:service.response.time:merge(\"dt.entity.service\"):percentile(95)&entitySelector=type(SERVICE),tag(keptn_project:sockshop),tag(keptn_stage:staging)",
 	})
 
-	assertThatCustomSLITestIsCorrect(t, handler, testIndicatorResponseTimeP95, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12.439619479902443, expectedMetricsRequest))
+	assertThatCustomSLITestIsCorrect(t, handler, testIndicatorResponseTimeP95, rClient, getSLIFinishedEventSuccessAssertionsFunc, createSuccessfulSLIResultAssertionsFunc(testIndicatorResponseTimeP95, 12439.619479902443, expectedMetricsRequest))
 }

--- a/internal/sli/query/query_processing.go
+++ b/internal/sli/query/query_processing.go
@@ -278,5 +278,5 @@ func (p *Processing) processMetricsQuery(ctx context.Context, name string, query
 	}
 
 	singleValue := singleDataPoint.Values[0]
-	return result.NewSuccessfulSLIResultWithQuery(name, unit.ScaleData(query.GetMetricSelector(), metricUnit, singleValue), request.RequestString())
+	return result.NewSuccessfulSLIResultWithQuery(name, unit.ScaleData(metricUnit, singleValue), request.RequestString())
 }

--- a/internal/sli/query/query_processing_test.go
+++ b/internal/sli/query/query_processing_test.go
@@ -29,7 +29,7 @@ func TestGetSLIValueMetricsQuery_Success(t *testing.T) {
 
 	sliResult := runGetSLIResultFromIndicatorTest(t, handler)
 
-	assert.EqualValues(t, 287.10692602352884/1000, sliResult.Value())
+	assert.EqualValues(t, 287.10692602352884, sliResult.Value())
 	assert.EqualValues(t, result.IndicatorResultSuccessful, sliResult.IndicatorResult())
 	assert.True(t, sliResult.Success())
 }
@@ -153,7 +153,7 @@ func TestGetSLIValue(t *testing.T) {
 	sliResult := runGetSLIResultFromIndicatorTest(t, handler)
 
 	assert.True(t, sliResult.Success())
-	assert.InDelta(t, 8.43340, sliResult.Value(), 0.001)
+	assert.InDelta(t, 8433.40, sliResult.Value(), 0.001)
 }
 
 // tests the GETSliValue function to return the proper datapoint with the old custom query format
@@ -204,7 +204,7 @@ func TestGetSLIValueWithOldAndNewCustomQueryFormat(t *testing.T) {
 		sliResult := p.GetSLIResultFromIndicator(context.TODO(), responseTimeP50)
 
 		assert.True(t, sliResult.Success())
-		assert.InDelta(t, 8.43340, sliResult.Value(), 0.001)
+		assert.InDelta(t, 8433.40, sliResult.Value(), 0.001)
 	}
 }
 
@@ -290,7 +290,7 @@ func TestGetSLISleep(t *testing.T) {
 	getSLIExectutionTime := time.Since(timeBeforeGetSLIValue)
 
 	assert.True(t, sliResult.Success())
-	assert.InDelta(t, 8.43340, sliResult.Value(), 0.001)
+	assert.InDelta(t, 8433.40, sliResult.Value(), 0.001)
 
 	assert.InDelta(t, 5, getSLIExectutionTime.Seconds(), 5)
 }
@@ -426,7 +426,7 @@ func TestGetSLIValueSupportsPlaceholders(t *testing.T) {
 		{
 			indicator:        "response_time2",
 			query:            "entitySelector=type(SERVICE),tag(\"keptn_deployment:$DEPLOYMENT\"),tag(\"context:$CONTEXT\"),tag(\"keptn_stage:$STAGE\"),tag(\"keptn_service:$SERVICE\")&metricSelector=builtin:service.response.time",
-			expectedSLIValue: 0.29,
+			expectedSLIValue: 290,
 		},
 		{
 			indicator:        "problems",

--- a/internal/sli/unit/units.go
+++ b/internal/sli/unit/units.go
@@ -2,18 +2,14 @@ package unit
 
 import (
 	"regexp"
-	"strings"
 )
 
 var microSecondPattern = regexp.MustCompile(`^[Mm]icro[Ss]econd$`)
 var bytePattern = regexp.MustCompile(`^[Bb]yte$`)
 
-// ScaleData
-// scales data based on the timeseries identifier (e.g., service.responsetime needs to be scaled from microseconds to milliseocnds)
-// Right now this method scales microseconds to milliseconds and bytes to Kilobytes
-// At a later stage we should extend this with more conversions and even think of allowing custom scale targets, e.g: Byte to MegaByte
-func ScaleData(metricID string, unit string, value float64) float64 {
-	if isMicroSecondUnit(unit) || strings.Contains(metricID, "builtin:service.response.time") {
+// ScaleData scales data based on the unit, i.e converts microseconds to milliseconds and bytes to Kilobytes.
+func ScaleData(unit string, value float64) float64 {
+	if isMicroSecondUnit(unit) {
 		// scale from microseconds to milliseconds
 		return value / 1000.0
 	}

--- a/internal/sli/unit/units_test.go
+++ b/internal/sli/unit/units_test.go
@@ -1,8 +1,9 @@
 package unit
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScaleDataWithUnit(t *testing.T) {
@@ -61,45 +62,7 @@ func TestScaleDataWithUnit(t *testing.T) {
 	for _, testConfig := range testConfigs {
 		tc := testConfig
 		t.Run(tc.name, func(t *testing.T) {
-			actual := ScaleData("", tc.unit, tc.inputValue)
-
-			assert.EqualValues(t, tc.expectedResult, actual)
-		})
-	}
-}
-
-func TestScaleDataWithResponseTime(t *testing.T) {
-	testConfigs := []struct {
-		name           string
-		metricID       string
-		inputValue     float64
-		expectedResult float64
-	}{
-		// response time
-		{
-			name:           "builtin:service.response.time works",
-			metricID:       "builtin:service.response.time",
-			inputValue:     1000000.0,
-			expectedResult: 1000.0,
-		},
-		// units for unknown metric IDs are unchanged
-		{
-			name:           "service.response.time substring does not work",
-			metricID:       "service.response.time",
-			inputValue:     123.0,
-			expectedResult: 123.0,
-		},
-		{
-			name:           "builtin:service.response substring does not work",
-			metricID:       "builtin:service.response",
-			inputValue:     123.0,
-			expectedResult: 123.0,
-		},
-	}
-	for _, testConfig := range testConfigs {
-		tc := testConfig
-		t.Run(tc.name, func(t *testing.T) {
-			actual := ScaleData(tc.metricID, "", tc.inputValue)
+			actual := ScaleData(tc.unit, tc.inputValue)
 
 			assert.EqualValues(t, tc.expectedResult, actual)
 		})


### PR DESCRIPTION
This PR:
- removes automatic conversion of microseconds to milliseconds for `builtin:service.response.time` metric
- removes automatic conversion of microseconds to milliseconds or bytes to kilobytes for dashboard-based Metrics-V2-based  SLIs
- provides examples of how to achieve the same functionality using `:toUnit(...)` transformation or `MV2;` prefix