### PR TITLE
fix: Trim whitespace from key-value pairs in markdown tiles

### DIFF
--- a/internal/sli/dashboard/markdown_tile_processing.go
+++ b/internal/sli/dashboard/markdown_tile_processing.go
@@ -98,9 +98,9 @@ func parseMarkdownConfiguration(markdown string, totalScore keptncommon.SLOScore
 			continue
 		}
 
-		// lets separate key and value
-		key := strings.ToLower(configValueSplits[0])
-		value := configValueSplits[1]
+		// separate key and value and trim whitespace
+		key := strings.ToLower(strings.TrimSpace(configValueSplits[0]))
+		value := strings.TrimSpace(configValueSplits[1])
 
 		switch key {
 		case TotalPass:

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_markdown_test.go
@@ -112,6 +112,21 @@ func TestRetrieveMetricsFromDashboard_MarkdownParsingWorks(t *testing.T) {
 			markdown:    "KQG.Total.Pass=95%;KQG.Total.Warning=75%;KQG.Compare.WithScore=pass_or_warn;KQG.Compare.Results=6;KQG.Compare.Function=p95",
 			expectedSLO: createSLO("95%", "75%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePassOrWarn, 6, dashboard.CompareFunctionP95, expectedSLO),
 		},
+		{
+			name:        "newline at the end",
+			markdown:    "KQG.Total.Pass=85%;KQG.Total.Warning=80%;KQG.Compare.WithScore=pass;KQG.Compare.Results=3;KQG.Compare.Function=avg\\n",
+			expectedSLO: createSLO("85%", "80%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 3, dashboard.CompareFunctionAvg, expectedSLO),
+		},
+		{
+			name:        "newline after every key value pair",
+			markdown:    "KQG.Total.Pass=85%;\\nKQG.Total.Warning=80%;\\nKQG.Compare.WithScore=pass;\\nKQG.Compare.Results=3;\\nKQG.Compare.Function=avg\\n",
+			expectedSLO: createSLO("85%", "80%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 3, dashboard.CompareFunctionAvg, expectedSLO),
+		},
+		{
+			name:        "whitespace around each key-value pair",
+			markdown:    "KQG.Total.Pass = 85%;\\nKQG.Total.Warning = 80%;\\nKQG.Compare.WithScore = pass;\\nKQG.Compare.Results = 3;\\nKQG.Compare.Function = avg\\n",
+			expectedSLO: createSLO("85%", "80%", dashboard.CompareResultsMultiple, dashboard.CompareWithScorePass, 3, dashboard.CompareFunctionAvg, expectedSLO),
+		},
 	}
 	for _, markdownTest := range tests {
 		t.Run(markdownTest.name, func(t *testing.T) {


### PR DESCRIPTION
This PR:
- trims whitespace from key-value pairs from markdown tiles

This prevents also issues with additional whitespace at the end of markdown tiles.
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>