### PR TITLE
fix: Support auto space aggregation

### DIFF
--- a/internal/sli/dashboard/data_explorer_tile_processing.go
+++ b/internal/sli/dashboard/data_explorer_tile_processing.go
@@ -254,6 +254,8 @@ func processFilter(entityType string, filter *dynatrace.DataExplorerFilter) (*pr
 
 func getSpaceAggregationTransformation(spaceAggregation string) (string, error) {
 	switch spaceAggregation {
+	case "":
+		return "auto", nil
 	case "AVG":
 		return "avg", nil
 	case "SUM":

--- a/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
+++ b/internal/sli/get_sli_triggered_event_handler_retrieve_metrics_from_dashboard_data_explorer_test.go
@@ -246,17 +246,23 @@ func TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgSumNoFilterBy(t *te
 	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
 }
 
-// TestRetrieveMetricsFromDashboardDataExplorerTile_NoSpaceAgNoFilterBy tests no space aggregation and no filterby.
-// This is will result in a SLIResult with failure, as a space aggregation must be supplied.
+// TestRetrieveMetricsFromDashboardDataExplorerTile_NoSpaceAgNoFilterBy tests no space aggregation set and no filterby.
+// This is will result in a SLIResult with success, as this is supported: auto will be used as the space aggregation
 func TestRetrieveMetricsFromDashboardDataExplorerTile_NoSpaceAgNoFilterBy(t *testing.T) {
 	const testDataFolder = "./testdata/dashboards/data_explorer/no_spaceag_no_filterby/"
 
-	handler := test.NewFileBasedURLHandler(t)
+	expectedMetricsRequest := buildMetricsV2RequestString("builtin%3Aservice.response.time%3AsplitBy%28%29%3Aauto%3Anames")
 
+	handler := test.NewFileBasedURLHandler(t)
 	handler.AddExact(dynatrace.DashboardsPath+"/"+testDashboardID, testDataFolder+"dashboard_no_spaceag_no_filterby.json")
 	handler.AddExact(dynatrace.MetricsPath+"/builtin:service.response.time", testDataFolder+"metrics_builtin_service_response_time.json")
+	handler.AddExact(expectedMetricsRequest, testDataFolder+"metrics_query_builtin_service_response_time_auto.json")
 
-	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventFailureAssertionsFunc, createFailedSLIResultAssertionsFunc("rt"))
+	sliResultsAssertionsFuncs := []func(t *testing.T, actual sliResult){
+		createSuccessfulSLIResultAssertionsFunc("rt", 29192.929640271974, expectedMetricsRequest),
+	}
+
+	runGetSLIsFromDashboardTestAndCheckSLIs(t, handler, testGetSLIEventData, getSLIFinishedEventSuccessAssertionsFunc, sliResultsAssertionsFuncs...)
 }
 
 // TestRetrieveMetricsFromDashboardDataExplorerTile_SpaceAgAvgFilterById tests average space aggregation and filterby entity id.

--- a/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/dashboard_no_spaceag_no_filterby.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/dashboard_no_spaceag_no_filterby.json
@@ -28,7 +28,6 @@
           {
             "id": "A",
             "metric": "builtin:service.response.time",
-            "spaceAggregation": "",
             "timeAggregation": "DEFAULT",
             "splitBy": [],
             "filterBy": {

--- a/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/metrics_query_builtin_service_response_time_auto.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/metrics_query_builtin_service_response_time_auto.json
@@ -4,7 +4,7 @@
   "resolution": "Inf",
   "result": [
     {
-      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):avg:names",
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):auto:names",
       "data": [
         {
           "dimensions": [],


### PR DESCRIPTION
This PR adds support for auto space aggregation in Data Explorer tiles by making `auto` the default when no space aggregation is specified.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>