### PR TITLE
fix: Support auto space aggregation

### DIFF
--- a/internal/sli/dashboard/data_explorer_tile_processing.go
+++ b/internal/sli/dashboard/data_explorer_tile_processing.go
@@ -222,6 +222,8 @@ func processFilter(entityType string, filter *dynatrace.DataExplorerFilter) (*pr
 
 func getSpaceAggregationTransformation(spaceAggregation string) (string, error) {
 	switch spaceAggregation {
+	case "":
+		return "auto", nil
 	case "AVG":
 		return "avg", nil
 	case "SUM":

--- a/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/dashboard_no_spaceag_no_filterby.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/dashboard_no_spaceag_no_filterby.json
@@ -28,7 +28,6 @@
           {
             "id": "A",
             "metric": "builtin:service.response.time",
-            "spaceAggregation": "",
             "timeAggregation": "DEFAULT",
             "splitBy": [],
             "filterBy": {

--- a/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/metrics_query_builtin_service_response_time_auto.json
+++ b/internal/sli/testdata/dashboards/data_explorer/no_spaceag_no_filterby/metrics_query_builtin_service_response_time_auto.json
@@ -4,7 +4,7 @@
   "resolution": "Inf",
   "result": [
     {
-      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):avg:names",
+      "metricId": "builtin:service.response.time:merge(\"dt.entity.service\"):auto:names",
       "data": [
         {
           "dimensions": [],


### PR DESCRIPTION
This PR adds support to branch 0.23.x for auto space aggregation in Data Explorer tiles by making auto the default when no space aggregation is specified.

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>