### PR TITLE
build(deps): manual bump dawidd6/action-download-artifact from 2.21.1…

### DIFF
--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -89,7 +89,7 @@ jobs:
           echo "::set-output name=RUN_ID::$RUN_ID"
 
       - name: Download all artifacts from last successful build of specified branch
-        uses: dawidd6/action-download-artifact@v2.21.1
+        uses: dawidd6/action-download-artifact@v2.22.0
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           # Required, workflow file name or ID


### PR DESCRIPTION
… to 2.22.0

Bumps [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact) from 2.21.1 to 2.22.0.
- [Release notes](https://github.com/dawidd6/action-download-artifact/releases)
- [Commits](https://github.com/dawidd6/action-download-artifact/compare/v2.21.1...v2.22.0)

---
updated-dependencies:
- dependency-name: dawidd6/action-download-artifact
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>