### PR TITLE
ci: remove token from checkout action in verify-next-version job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3.0.2
-        with:
-          token: ${{ secrets.KEPTN_BOT_TOKEN }}
       - name: Overwrite version variable from prepare_ci_run in case of a release-please-branch
         id: verify-next-version
         run: |


### PR DESCRIPTION
Signed-off-by: Dietmar Schnitzer <103405584+dietmar-91@users.noreply.github.com>