### PR TITLE
fix: Generate specific error message if no SLIs are requested when using file-based SLIs

### DIFF
--- a/internal/sli/get_sli_triggered_event_handler.go
+++ b/internal/sli/get_sli_triggered_event_handler.go
@@ -151,6 +151,10 @@ func (eh *GetSLIEventHandler) getSLIResultsFromDynatraceDashboard(ctx context.Co
 }
 
 func (eh *GetSLIEventHandler) getSLIResultsFromCustomQueries(ctx context.Context, timeframe common.Timeframe) ([]result.SLIResult, error) {
+	if len(eh.event.GetIndicators()) == 0 {
+		return nil, errors.New("no SLIs were requested")
+	}
+
 	slis, err := eh.resourceClient.GetSLIs(ctx, eh.event.GetProject(), eh.event.GetStage(), eh.event.GetService())
 	if err != nil {
 		log.WithError(err).Error("could not retrieve custom SLI definitions")

--- a/internal/sli/test_helper_test.go
+++ b/internal/sli/test_helper_test.go
@@ -55,6 +55,17 @@ func createTestGetSLIEventDataWithIndicator(indicator string) *getSLIEventData {
 	}
 }
 
+func createTestGetSLIEventDataWithNoIndicators() *getSLIEventData {
+	return &getSLIEventData{
+		project:    "sockshop",
+		stage:      "staging",
+		service:    "carts",
+		indicators: []string{},
+		sliStart:   testSLIStart,
+		sliEnd:     testSLIEnd,
+	}
+}
+
 // convertTimeStringToUnixMillisecondsString converts a ISO8601 (or fallback format RFC3339) time string to a string with the Unix timestamp, or "0" if this cannot be done.
 func convertTimeStringToUnixMillisecondsString(timeString string) string {
 	time, err := timeutils.ParseTimestamp(timeString)


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>