### PR TITLE
ci: update release-please workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - "master"
-      - "release-*"
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,9 +58,9 @@ jobs:
           if [[ "${GITHUB_HEAD_REF}" == "release-please-"* ]]; then
             # Release PR: extract version from x-release-please-version.json
             RELEASEPLEASE_VERSION=$(jq -r '."x-release-please-version"' ${{ env.VERSION_FILE }})
-            echo "::set-output name=NEXT-VERSION::${RELEASEPLEASE_VERSION}-rc"
+            echo "NEXT-VERSION=${RELEASEPLEASE_VERSION}-rc" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=NEXT-VERSION::${VERSION}"
+            echo "NEXT-VERSION=${VERSION}" >> $GITHUB_OUTPUT
           fi 
 
   ############################################################################

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -52,7 +52,7 @@ jobs:
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
 
   ############################################################################
   # Create Release-PR and special version updates

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -83,7 +83,7 @@ jobs:
           bump-patch-for-minor-pre-major: false
           include-v-in-tag: false
           signoff: "${{ env.KEPTN_BOT_NAME }} <${{ env.KEPTN_BOT_EMAIL }}>"
-          pull-request-title-pattern: "build: release ${version}"
+          pull-request-title-pattern: "build: release ${component} ${version}"
           extra-files: |
             ${{ env.VERSION_FILE }}
           changelog-types: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -63,7 +63,7 @@ jobs:
           bump-patch-for-minor-pre-major: false
           include-v-in-tag: false
           signoff: "${{ env.KEPTN_BOT_NAME }} <${{ env.KEPTN_BOT_EMAIL }}>"
-          pull-request-title-pattern: "build${scope}: release ${component} ${version}"
+          pull-request-title-pattern: "build: release ${component} ${version}"
           extra-files: |
             ${{ env.VERSION_FILE }}
           changelog-types: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
 
   ############################################################################
   # Create Release


### PR DESCRIPTION
- update deprecated set-output workflow command in release-please workflows (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- change pr-title-pattern of release-please
- remove release branches from on_pull_request event in ci workflow because through the branch protection rule the ci pipeline (ci_prepare_run, docker_build, unit_test) gets also triggered