### PR TITLE
build: remove commit message suffix for skipping ci builds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,5 @@
       "matchManagers": ["dockerfile"],
       "addLabels": ["docker"]
     }
-  ],
-  "commitMessageSuffix": "[skip ci]"
+  ]
 }


### PR DESCRIPTION
removes the flag to skip ci builds in workflows

Signed-off-by: Joerg Poecher <j-poecher@users.noreply.github.com>