### PR TITLE
build: disable gomodMassage in renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,7 @@
   "stabilityDays": 3,
   "timezone": "Europe/Vienna",
   "postUpdateOptions": [
-    "gomodTidy",
-    "gomodMassage"
+    "gomodTidy"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Disable `gomodMassage` option to see whether we can get rid of the artifacts from this renovate PR #1009 

We do not have any `replace` statements anyway, [but `keptn/go-utils` does](https://github.com/keptn/go-utils/blob/master/go.mod#L89-L96)

See [this explanation from renovate](https://github.com/keptn-contrib/dynatrace-service/pull/1010)

> Renovate can massage `replace` statements it finds prior to running `go` commands, and then massage them back afterwards. This capability was added - and originally default behavior - because relative `replace` statements outside of the current repo will not work when Renovate clones the repo locally. 
>
> On the other hand, this massaging of `replace` statements may lead to unexpected results, especially because `go mod tidy` may not fully tidy the `go.sum` if it is missing the replace directives in `go.mod`. It has therefore been disabled by default.