### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -86,7 +86,7 @@ jobs:
         id: last_run_id
         run: |
           RUN_ID=$(curl -sLH 'Accept: application/vnd.github.v3+json' -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs" | jq --arg branch "$BRANCH" -c '[.workflow_runs[] | select( .conclusion == "success" and .head_branch == $branch)][0] | .id')
-          echo "::set-output name=RUN_ID::$RUN_ID"
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
 
       - name: Download all artifacts from last successful build of specified branch
         uses: dawidd6/action-download-artifact@v2.28.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -83,14 +83,14 @@ jobs:
           fi
 
           NEXT_VERSION=$(cat VERSION.txt)
-          echo "::set-output name=next-version::${NEXT_VERSION}"
+          echo "next-version=${NEXT_VERSION}" >> $GITHUB_ENV
           git checkout HEAD -- VERSION.txt
 
       - name: Find current branch
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_ENV
 
   ############################################################################
   # Build Docker Image
@@ -203,7 +203,7 @@ jobs:
               --skip.changelog
           fi
 
-          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+          echo "tag-name=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       # No need for a PR here, because we do not want any changes to be committed. Just push the pre-release tag
       - name: Push Tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           fi
 
           NEXT_VERSION=$(cat VERSION.txt)
-          echo "::set-output name=next-version::${NEXT_VERSION}"
+          echo "next-version=${NEXT_VERSION}" >> $GITHUB_ENV
           git checkout HEAD -- VERSION.txt
 
           echo "::notice::Next version number: ${NEXT_VERSION}"
@@ -112,7 +112,7 @@ jobs:
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_ENV
 
   ############################################################################
   # Build Docker Image
@@ -281,7 +281,7 @@ jobs:
           fi
 
           TAG="$(git describe --tags --abbrev=0)"
-          echo "::set-output name=tag-name::$TAG"
+          echo "tag-name=$TAG" >> $GITHUB_ENV
 
           echo "Sign off commit"
           git commit --amend --signoff --no-edit


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


